### PR TITLE
Logging performance improvements

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "aries-askar"
-version = "0.1.2"
+version = "0.1.3"
 authors = ["Hyperledger Aries Contributors <aries@lists.hyperledger.org>"]
 edition = "2018"
 description = "Hyperledger Aries Askar secure storage"

--- a/src/ffi/log.rs
+++ b/src/ffi/log.rs
@@ -5,18 +5,18 @@ use std::ptr;
 use log::{LevelFilter, Metadata, Record};
 
 use super::error::ErrorCode;
+use crate::error::Error;
 
-pub type EnabledCallback =
-    extern "C" fn(context: *const c_void, level: u32, target: *const c_char) -> bool;
+pub type EnabledCallback = extern "C" fn(context: *const c_void, level: i32) -> i8;
 
 pub type LogCallback = extern "C" fn(
     context: *const c_void,
-    level: u32,
+    level: i32,
     target: *const c_char,
     message: *const c_char,
     module_path: *const c_char,
     file: *const c_char,
-    line: u32,
+    line: i32,
 );
 
 pub type FlushCallback = extern "C" fn(context: *const c_void);
@@ -47,10 +47,7 @@ impl CustomLogger {
 impl log::Log for CustomLogger {
     fn enabled(&self, metadata: &Metadata<'_>) -> bool {
         if let Some(enabled_cb) = self.enabled {
-            let level = metadata.level() as u32;
-            let target = CString::new(metadata.target()).unwrap();
-
-            enabled_cb(self.context, level, target.as_ptr())
+            enabled_cb(self.context, metadata.level() as i32) != 0
         } else {
             true
         }
@@ -59,13 +56,13 @@ impl log::Log for CustomLogger {
     fn log(&self, record: &Record<'_>) {
         let log_cb = self.log;
 
-        let level = record.level() as u32;
+        let level = record.level() as i32;
         let target = CString::new(record.target()).unwrap();
         let message = CString::new(record.args().to_string()).unwrap();
 
         let module_path = record.module_path().map(|s| CString::new(s).unwrap());
         let file = record.file().map(|s| CString::new(s).unwrap());
-        let line = record.line().unwrap_or(0);
+        let line = record.line().unwrap_or(0) as i32;
 
         log_cb(
             self.context,
@@ -97,11 +94,13 @@ pub extern "C" fn askar_set_custom_logger(
     log: LogCallback,
     enabled: Option<EnabledCallback>,
     flush: Option<FlushCallback>,
+    max_level: i32,
 ) -> ErrorCode {
     catch_err! {
+        let max_level = get_level_filter(max_level)?;
         let logger = CustomLogger::new(context, enabled, log, flush);
         log::set_boxed_logger(Box::new(logger)).map_err(err_map!(Unexpected))?;
-        log::set_max_level(LevelFilter::Trace);
+        log::set_max_level(max_level);
         debug!("Initialized custom logger");
         Ok(ErrorCode::Success)
     }
@@ -114,4 +113,29 @@ pub extern "C" fn askar_set_default_logger() -> ErrorCode {
         debug!("Initialized default logger");
         Ok(ErrorCode::Success)
     }
+}
+
+#[no_mangle]
+pub extern "C" fn askar_set_max_log_level(max_level: i32) -> ErrorCode {
+    catch_err! {
+        log::set_max_level(get_level_filter(max_level)?);
+        Ok(ErrorCode::Success)
+    }
+}
+
+fn get_level_filter(max_level: i32) -> Result<LevelFilter, Error> {
+    Ok(match max_level {
+        -1 => {
+            // load from RUST_LOG environment variable
+            // defaults to ERROR if unspecified
+            env_logger::Logger::from_default_env().filter()
+        }
+        0 => LevelFilter::Off,
+        1 => LevelFilter::Error,
+        2 => LevelFilter::Warn,
+        3 => LevelFilter::Info,
+        4 => LevelFilter::Debug,
+        5 => LevelFilter::Trace,
+        _ => return Err(err_msg!(Input, "Invalid log level")),
+    })
 }

--- a/wrappers/python/aries_askar/version.py
+++ b/wrappers/python/aries_askar/version.py
@@ -1,3 +1,3 @@
 """aries_askar library wrapper version."""
 
-__version__ = "0.1.2"
+__version__ = "0.1.3"

--- a/wrappers/python/demo/perf.py
+++ b/wrappers/python/demo/perf.py
@@ -1,9 +1,16 @@
 import asyncio
+import logging
+import os
 import sys
 import time
 
-from aries_askar.bindings import generate_raw_key, version
+from aries_askar.bindings import (
+    generate_raw_key,
+    version,
+)
 from aries_askar import Store
+
+logging.basicConfig(level=os.getenv("LOG_LEVEL", "").upper() or None)
 
 if len(sys.argv) > 1:
     REPO_URI = sys.argv[1]

--- a/wrappers/python/demo/test.py
+++ b/wrappers/python/demo/test.py
@@ -1,5 +1,6 @@
 import asyncio
 import logging
+import os
 import sys
 
 from aries_askar.bindings import (
@@ -10,8 +11,7 @@ from aries_askar.bindings import (
 )
 from aries_askar import KeyAlg, Store
 
-logging.basicConfig(level=logging.INFO)
-# logging.getLogger("aries_askar").setLevel(5)
+logging.basicConfig(level=os.getenv("LOG_LEVEL", "").upper() or None)
 
 if len(sys.argv) > 1:
     REPO_URI = sys.argv[1]


### PR DESCRIPTION
Adds more options for log filtering, respecting RUST_LOG when defined, and defaulting to the same level as the Python logger in that wrapper. Moving sqlx query logging to the DEBUG level should improve performance in general.