### PR TITLE
ECDH-1PU minor fixes

### DIFF
--- a/src/ffi/key.rs
+++ b/src/ffi/key.rs
@@ -27,9 +27,10 @@ pub extern "C" fn askar_key_generate(
     out: *mut LocalKeyHandle,
 ) -> ErrorCode {
     catch_err! {
-        trace!("Generate key: {}", alg.as_str());
+        let alg = alg.as_opt_str().unwrap_or_default();
+        trace!("Generate key: {}", alg);
         check_useful_c_ptr!(out);
-        let alg = KeyAlg::from_str(alg.as_str())?;
+        let alg = KeyAlg::from_str(alg)?;
         let key = LocalKey::generate(alg, ephemeral != 0)?;
         unsafe { *out = LocalKeyHandle::create(key) };
         Ok(ErrorCode::Success)
@@ -44,9 +45,10 @@ pub extern "C" fn askar_key_from_seed(
     out: *mut LocalKeyHandle,
 ) -> ErrorCode {
     catch_err! {
-        trace!("Create key from seed: {}", alg.as_str());
+        let alg = alg.as_opt_str().unwrap_or_default();
+        trace!("Create key from seed: {}", alg);
         check_useful_c_ptr!(out);
-        let alg = KeyAlg::from_str(alg.as_str())?;
+        let alg = KeyAlg::from_str(alg)?;
         let key = LocalKey::from_seed(alg, seed.as_slice(), method.as_opt_str())?;
         unsafe { *out = LocalKeyHandle::create(key) };
         Ok(ErrorCode::Success)
@@ -71,9 +73,10 @@ pub extern "C" fn askar_key_from_public_bytes(
     out: *mut LocalKeyHandle,
 ) -> ErrorCode {
     catch_err! {
-        trace!("Load key from public: {}", alg.as_str());
+        let alg = alg.as_opt_str().unwrap_or_default();
+        trace!("Load key from public: {}", alg);
         check_useful_c_ptr!(out);
-        let alg = KeyAlg::from_str(alg.as_str())?;
+        let alg = KeyAlg::from_str(alg)?;
         let key = LocalKey::from_public_bytes(alg, public.as_slice())?;
         unsafe { *out = LocalKeyHandle::create(key) };
         Ok(ErrorCode::Success)
@@ -102,9 +105,10 @@ pub extern "C" fn askar_key_from_secret_bytes(
     out: *mut LocalKeyHandle,
 ) -> ErrorCode {
     catch_err! {
-        trace!("Load key from secret: {}", alg.as_str());
+        let alg = alg.as_opt_str().unwrap_or_default();
+        trace!("Load key from secret: {}", alg);
         check_useful_c_ptr!(out);
-        let alg = KeyAlg::from_str(alg.as_str())?;
+        let alg = KeyAlg::from_str(alg)?;
         let key = LocalKey::from_secret_bytes(alg, secret.as_slice())?;
         unsafe { *out = LocalKeyHandle::create(key) };
         Ok(ErrorCode::Success)
@@ -133,9 +137,10 @@ pub extern "C" fn askar_key_convert(
     out: *mut LocalKeyHandle,
 ) -> ErrorCode {
     catch_err! {
-        trace!("Convert key: {} to {}", handle, alg.as_str());
+        let alg = alg.as_opt_str().unwrap_or_default();
+        trace!("Convert key: {} to {}", handle, alg);
         check_useful_c_ptr!(out);
-        let alg = KeyAlg::from_str(alg.as_str())?;
+        let alg = KeyAlg::from_str(alg)?;
         let key = handle.load()?.convert_key(alg)?;
         unsafe { *out = LocalKeyHandle::create(key) };
         Ok(ErrorCode::Success)
@@ -150,9 +155,10 @@ pub extern "C" fn askar_key_from_key_exchange(
     out: *mut LocalKeyHandle,
 ) -> ErrorCode {
     catch_err! {
-        trace!("Key exchange: {}, {}", sk_handle, pk_handle);
+        let alg = alg.as_opt_str().unwrap_or_default();
+        trace!("Key exchange: {}, {}, {}", alg, sk_handle, pk_handle);
         check_useful_c_ptr!(out);
-        let alg = KeyAlg::from_str(alg.as_str())?;
+        let alg = KeyAlg::from_str(alg)?;
         let sk = sk_handle.load()?;
         let pk = pk_handle.load()?;
         let key = sk.to_key_exchange(alg, &pk)?;
@@ -393,10 +399,11 @@ pub extern "C" fn askar_key_unwrap_key(
     out: *mut LocalKeyHandle,
 ) -> ErrorCode {
     catch_err! {
+        let alg = alg.as_opt_str().unwrap_or_default();
         trace!("Unwrap key: {}", handle);
         check_useful_c_ptr!(out);
         let key = handle.load()?;
-        let alg = KeyAlg::from_str(alg.as_str())?;
+        let alg = KeyAlg::from_str(alg)?;
         let result = key.unwrap_key(alg, (ciphertext.as_slice(), tag.as_slice()), nonce.as_slice())?;
         unsafe { *out = LocalKeyHandle::create(result) };
         Ok(ErrorCode::Success)
@@ -506,9 +513,10 @@ pub extern "C" fn askar_key_derive_ecdh_es(
     out: *mut LocalKeyHandle,
 ) -> ErrorCode {
     catch_err! {
-        trace!("ECDH-ES: {}", alg.as_str());
+        let alg = alg.as_opt_str().unwrap_or_default();
+        trace!("ECDH-ES: {}", alg);
         check_useful_c_ptr!(out);
-        let alg = KeyAlg::from_str(alg.as_str())?;
+        let alg = KeyAlg::from_str(alg)?;
         let ephem_key = ephem_key.load()?;
         let recip_key = recip_key.load()?;
         let key = derive_key_ecdh_es(
@@ -539,9 +547,10 @@ pub extern "C" fn askar_key_derive_ecdh_1pu(
     out: *mut LocalKeyHandle,
 ) -> ErrorCode {
     catch_err! {
-        trace!("ECDH-1PU: {}", alg.as_str());
+        let alg = alg.as_opt_str().unwrap_or_default();
+        trace!("ECDH-1PU: {}", alg);
         check_useful_c_ptr!(out);
-        let alg = KeyAlg::from_str(alg.as_str())?;
+        let alg = KeyAlg::from_str(alg)?;
         let ephem_key = ephem_key.load()?;
         let sender_key = sender_key.load()?;
         let recip_key = recip_key.load()?;

--- a/wrappers/python/aries_askar/ecdh.py
+++ b/wrappers/python/aries_askar/ecdh.py
@@ -44,7 +44,7 @@ class EcdhEs:
         receiver_key: Union[dict, str, Key],
         message: Union[str, bytes],
         *,
-        aad: bytes,
+        aad: bytes = None,
         nonce: bytes = None,
     ) -> Encrypted:
         derived = self._derive_key(
@@ -61,7 +61,7 @@ class EcdhEs:
         *,
         nonce: bytes,
         tag: bytes,
-        aad: bytes,
+        aad: bytes = None,
     ) -> bytes:
         derived = self._derive_key(
             enc_alg, _load_key(ephemeral_key), _load_key(receiver_key), True
@@ -88,8 +88,8 @@ class EcdhEs:
         receiver_key: Union[dict, str, Key],
         ciphertext: bytes,
         *,
-        tag: bytes = None,
         nonce: bytes = None,
+        tag: bytes = None,
     ) -> Key:
         derived = self._derive_key(
             wrap_alg, _load_key(ephemeral_key), _load_key(receiver_key), True
@@ -135,7 +135,7 @@ class Ecdh1PU:
         receiver_key: Union[dict, str, Key],
         message: Union[str, bytes],
         *,
-        aad: bytes,
+        aad: bytes = None,
         nonce: bytes = None,
     ) -> Encrypted:
         derived = self._derive_key(
@@ -158,7 +158,7 @@ class Ecdh1PU:
         *,
         nonce: bytes,
         tag: bytes,
-        aad: bytes,
+        aad: bytes = None,
     ) -> bytes:
         derived = self._derive_key(
             enc_alg,
@@ -178,15 +178,15 @@ class Ecdh1PU:
         receiver_key: Union[dict, str, Key],
         cek: Key,
         *,
-        tag: bytes,
+        cc_tag: bytes,
     ) -> Encrypted:
         derived = self._derive_key(
             wrap_alg,
             _load_key(ephemeral_key),
             _load_key(sender_key),
             _load_key(receiver_key),
-            tag,
-            False,
+            cc_tag=cc_tag,
+            receive=False,
         )
         return derived.wrap_key(cek)
 
@@ -199,15 +199,16 @@ class Ecdh1PU:
         receiver_key: Union[dict, str, Key],
         ciphertext: bytes,
         *,
-        tag: bytes,
+        cc_tag: bytes,
         nonce: bytes = None,
+        tag: bytes = None,
     ) -> Key:
         derived = self._derive_key(
             wrap_alg,
             _load_key(ephemeral_key),
             _load_key(sender_key),
             _load_key(receiver_key),
-            tag,
-            True,
+            cc_tag=cc_tag,
+            receive=True,
         )
         return derived.unwrap_key(enc_alg, ciphertext, nonce=nonce, tag=tag)

--- a/wrappers/python/tests/test_jose_ecdh.py
+++ b/wrappers/python/tests/test_jose_ecdh.py
@@ -227,6 +227,17 @@ def test_ecdh_1pu_wrapped_expected():
         "sjNXH8-LIRLycq8CHJQbDwvQeU1cSl55cQ0hGezJu2N9IY0QN"
     )
 
+    # test sender_wrap_key
+    encrypted_key_2 = Ecdh1PU(alg, apu, apv).sender_wrap_key(
+        KeyAlg.A128KW,
+        ephem,
+        alice,
+        bob,
+        cek,
+        cc_tag=cc_tag,
+    )
+    assert encrypted_key_2.ciphertext_tag == encrypted_key
+
     # Skipping key derivation for Charlie.
     # Assemble encrypted_key, iv, cc_tag, ciphertext, and headers into a JWE envelope here.
     # Receiver disassembles envelope and..
@@ -247,3 +258,15 @@ def test_ecdh_1pu_wrapped_expected():
         ciphertext, nonce=iv, aad=protected_b64, tag=cc_tag
     )
     assert message_recv == message
+
+    # test receiver_wrap_key
+    cek_recv_2 = Ecdh1PU(alg, apu, apv).receiver_unwrap_key(
+        KeyAlg.A128KW,
+        KeyAlg.A256CBC_HS512,
+        ephem,
+        sender_key=alice,
+        receiver_key=bob,
+        ciphertext=encrypted_key,
+        cc_tag=cc_tag,
+    )
+    assert cek_recv_2.get_jwk_secret() == cek.get_jwk_secret()


### PR DESCRIPTION
FFI: Avoid a trapped panic when a null pointer is passed as a key algorithm name

Python wrapper: Add a `cc_tag` parameter to `Ecdh1PU.receiver_unwrap_key`, extend unit test
