### PR TITLE
Fix: encrypt keys for new profiles

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -183,6 +183,7 @@ jobs:
           python setup.py bdist_wheel --python-tag=py3 --plat-name=${{ matrix.plat-name }}
           pip install pytest pytest-asyncio dist/*
           python -m pytest
+          TEST_STORE_URI=sqlite://test.db python -m pytest
         working-directory: wrappers/python
 
       - if: "runner.os == 'Linux'"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -34,6 +34,8 @@ jobs:
 
       - name: Cache cargo resources
         uses: Swatinem/rust-cache@v1
+        with:
+          sharedKey: deps
 
       - name: Cargo check
         uses: actions-rs/cargo@v1
@@ -58,6 +60,47 @@ jobs:
         with:
           command: test
           args: --workspace
+
+  test-postgres:
+    name: Postgres
+    runs-on: ubuntu-latest
+    needs: [check]
+
+    services:
+      postgres:
+        image: postgres
+        env:
+          POSTGRES_PASSWORD: postgres
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+        ports:
+          - 5432:5432
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Install Rust toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: stable
+
+      - name: Cache cargo resources
+        uses: Swatinem/rust-cache@v1
+        with:
+          sharedKey: deps
+
+      - name: Test
+        uses: actions-rs/cargo@v1
+        env:
+          POSTGRES_URL: postgres://postgres:postgres@localhost:5432/test-db
+        with:
+          command: test
+          args: --features pg_test
 
   build-manylinux:
     name: Build Library
@@ -85,6 +128,8 @@ jobs:
 
       - name: Cache cargo resources
         uses: Swatinem/rust-cache@v1
+        with:
+          sharedKey: deps
 
       - name: Build library
         env:
@@ -126,6 +171,8 @@ jobs:
 
       - name: Cache cargo resources
         uses: Swatinem/rust-cache@v1
+        with:
+          sharedKey: deps
 
       - name: Build library
         env:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["askar-crypto"]
 
 [package]
 name = "aries-askar"
-version = "0.2.1"
+version = "0.2.2"
 authors = ["Hyperledger Aries Contributors <aries@lists.hyperledger.org>"]
 edition = "2018"
 description = "Hyperledger Aries Askar secure storage"

--- a/askar-crypto/Cargo.toml
+++ b/askar-crypto/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "askar-crypto"
-version = "0.2.1"
+version = "0.2.2"
 authors = ["Hyperledger Aries Contributors <aries@lists.hyperledger.org>"]
 edition = "2018"
 description = "Hyperledger Aries Askar cryptography"

--- a/src/backend/db_utils.rs
+++ b/src/backend/db_utils.rs
@@ -609,6 +609,13 @@ pub fn init_keys<'a>(
     method: StoreKeyMethod,
     pass_key: PassKey<'a>,
 ) -> Result<(ProfileKey, Vec<u8>, StoreKey, String), Error> {
+    if method == StoreKeyMethod::RawKey && pass_key.is_empty() {
+        // disallow random key for a new database
+        return Err(err_msg!(
+            Input,
+            "Cannot create a store with a blank raw key"
+        ));
+    }
     let (store_key, store_key_ref) = method.resolve(pass_key)?;
     let profile_key = ProfileKey::new()?;
     let enc_profile_key = encode_profile_key(&profile_key, &store_key)?;

--- a/tests/docker_pg.sh
+++ b/tests/docker_pg.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env sh
+docker run --rm -p 5432:5432 --name aries-test-postgres -e POSTGRES_PASSWORD=mysecretpassword -d postgres
+if [ $? != "0" ]; then
+  echo "Error starting postgres container"
+  exit 1
+fi
+echo POSTGRES_URL=postgres://postgres:mysecretpassword@localhost:5432/test-db cargo test --features pg_test

--- a/wrappers/python/aries_askar/store.py
+++ b/wrappers/python/aries_askar/store.py
@@ -271,7 +271,7 @@ class Store:
     @classmethod
     def generate_raw_key(cls, seed: Union[str, bytes] = None) -> str:
         """Generate a new raw key for a Store."""
-        bindings.generate_raw_key(seed)
+        return bindings.generate_raw_key(seed)
 
     @property
     def handle(self) -> StoreHandle:

--- a/wrappers/python/aries_askar/version.py
+++ b/wrappers/python/aries_askar/version.py
@@ -1,3 +1,3 @@
 """aries_askar library wrapper version."""
 
-__version__ = "0.2.1"
+__version__ = "0.2.2"


### PR DESCRIPTION
This would be a security issue, except that it was not possible to actually use the newly created profiles.

Fixes #19 