### PR TITLE
Fixes #26 Incorrect signature type is used for P256KeyPair

### DIFF
--- a/askar-crypto/src/alg/p256.rs
+++ b/askar-crypto/src/alg/p256.rs
@@ -194,7 +194,7 @@ impl KeySign for P256KeyPair {
         out: &mut dyn WriteBuffer,
     ) -> Result<(), Error> {
         match sig_type {
-            None | Some(SignatureType::ES256K) => {
+            None | Some(SignatureType::ES256) => {
                 if let Some(sig) = self.sign(message) {
                     out.buffer_write(&sig[..])?;
                     Ok(())


### PR DESCRIPTION
* Fixes #26 Incorrect signature type is used for P256KeyPair
* Use compatible signature type inside of KeySign::write_signature for P256KeyPair