### PR TITLE
Check JWK parameters when deserializing for specific key type

### DIFF
--- a/askar-crypto/src/alg/any.rs
+++ b/askar-crypto/src/alg/any.rs
@@ -524,11 +524,11 @@ fn from_jwk_any<R: AllocKey>(jwk: JwkParts<'_>) -> Result<R, Error> {
             X25519KeyPair::from_jwk_parts(jwk).map(R::alloc_key)
         }
         #[cfg(feature = "bls")]
-        ("EC", c) if c == G1::JWK_CURVE => BlsKeyPair::<G1>::from_jwk_parts(jwk).map(R::alloc_key),
+        ("OKP", c) if c == G1::JWK_CURVE => BlsKeyPair::<G1>::from_jwk_parts(jwk).map(R::alloc_key),
         #[cfg(feature = "bls")]
-        ("EC", c) if c == G2::JWK_CURVE => BlsKeyPair::<G2>::from_jwk_parts(jwk).map(R::alloc_key),
+        ("OKP", c) if c == G2::JWK_CURVE => BlsKeyPair::<G2>::from_jwk_parts(jwk).map(R::alloc_key),
         #[cfg(feature = "bls")]
-        ("EC", c) if c == G1G2::JWK_CURVE => {
+        ("OKP", c) if c == G1G2::JWK_CURVE => {
             BlsKeyPair::<G1G2>::from_jwk_parts(jwk).map(R::alloc_key)
         }
         #[cfg(feature = "k256")]

--- a/askar-crypto/src/alg/ed25519.rs
+++ b/askar-crypto/src/alg/ed25519.rs
@@ -269,6 +269,12 @@ impl ToJwk for Ed25519KeyPair {
 
 impl FromJwk for Ed25519KeyPair {
     fn from_jwk_parts(jwk: JwkParts<'_>) -> Result<Self, Error> {
+        if jwk.kty != JWK_KEY_TYPE {
+            return Err(err_msg!(InvalidKeyData, "Unsupported key type"));
+        }
+        if jwk.crv != JWK_CURVE {
+            return Err(err_msg!(InvalidKeyData, "Unsupported key algorithm"));
+        }
         ArrayKey::<U32>::temp(|pk_arr| {
             if jwk.x.decode_base64(pk_arr)? != pk_arr.len() {
                 Err(err_msg!(InvalidKeyData))
@@ -373,7 +379,7 @@ mod tests {
             .to_jwk_secret(None)
             .expect("Error converting private key to JWK");
         let jwk = JwkParts::from_slice(&jwk).expect("Error parsing JWK output");
-        assert_eq!(jwk.kty, "OKP");
+        assert_eq!(jwk.kty, JWK_KEY_TYPE);
         assert_eq!(jwk.crv, JWK_CURVE);
         assert_eq!(jwk.x, test_pub_b64);
         assert_eq!(jwk.d, test_pvt_b64);

--- a/askar-crypto/src/alg/k256.rs
+++ b/askar-crypto/src/alg/k256.rs
@@ -256,6 +256,12 @@ impl ToJwk for K256KeyPair {
 
 impl FromJwk for K256KeyPair {
     fn from_jwk_parts(jwk: JwkParts<'_>) -> Result<Self, Error> {
+        if jwk.kty != JWK_KEY_TYPE {
+            return Err(err_msg!(InvalidKeyData, "Unsupported key type"));
+        }
+        if jwk.crv != JWK_CURVE {
+            return Err(err_msg!(InvalidKeyData, "Unsupported key algorithm"));
+        }
         let pk_x = ArrayKey::<FieldSize>::try_new_with(|arr| {
             if jwk.x.decode_base64(arr)? != arr.len() {
                 Err(err_msg!(InvalidKeyData))
@@ -334,7 +340,7 @@ mod tests {
 
         let jwk = sk.to_jwk_public(None).expect("Error converting key to JWK");
         let jwk = JwkParts::from_str(&jwk).expect("Error parsing JWK");
-        assert_eq!(jwk.kty, "EC");
+        assert_eq!(jwk.kty, JWK_KEY_TYPE);
         assert_eq!(jwk.crv, JWK_CURVE);
         assert_eq!(jwk.x, test_pub_b64.0);
         assert_eq!(jwk.y, test_pub_b64.1);
@@ -344,7 +350,7 @@ mod tests {
 
         let jwk = sk.to_jwk_secret(None).expect("Error converting key to JWK");
         let jwk = JwkParts::from_slice(&jwk).expect("Error parsing JWK");
-        assert_eq!(jwk.kty, "EC");
+        assert_eq!(jwk.kty, JWK_KEY_TYPE);
         assert_eq!(jwk.crv, JWK_CURVE);
         assert_eq!(jwk.x, test_pub_b64.0);
         assert_eq!(jwk.y, test_pub_b64.1);

--- a/askar-crypto/src/alg/p256.rs
+++ b/askar-crypto/src/alg/p256.rs
@@ -256,6 +256,12 @@ impl ToJwk for P256KeyPair {
 
 impl FromJwk for P256KeyPair {
     fn from_jwk_parts(jwk: JwkParts<'_>) -> Result<Self, Error> {
+        if jwk.kty != JWK_KEY_TYPE {
+            return Err(err_msg!(InvalidKeyData, "Unsupported key type"));
+        }
+        if jwk.crv != JWK_CURVE {
+            return Err(err_msg!(InvalidKeyData, "Unsupported key algorithm"));
+        }
         let pk_x = ArrayKey::<FieldSize>::try_new_with(|arr| {
             if jwk.x.decode_base64(arr)? != arr.len() {
                 Err(err_msg!(InvalidKeyData))
@@ -332,7 +338,7 @@ mod tests {
 
         let jwk = sk.to_jwk_public(None).expect("Error converting key to JWK");
         let jwk = JwkParts::from_str(&jwk).expect("Error parsing JWK");
-        assert_eq!(jwk.kty, "EC");
+        assert_eq!(jwk.kty, JWK_KEY_TYPE);
         assert_eq!(jwk.crv, JWK_CURVE);
         assert_eq!(jwk.x, test_pub_b64.0);
         assert_eq!(jwk.y, test_pub_b64.1);
@@ -342,7 +348,7 @@ mod tests {
 
         let jwk = sk.to_jwk_secret(None).expect("Error converting key to JWK");
         let jwk = JwkParts::from_slice(&jwk).expect("Error parsing JWK");
-        assert_eq!(jwk.kty, "EC");
+        assert_eq!(jwk.kty, JWK_KEY_TYPE);
         assert_eq!(jwk.crv, JWK_CURVE);
         assert_eq!(jwk.x, test_pub_b64.0);
         assert_eq!(jwk.y, test_pub_b64.1);

--- a/askar-crypto/src/alg/x25519.rs
+++ b/askar-crypto/src/alg/x25519.rs
@@ -193,6 +193,12 @@ impl ToJwk for X25519KeyPair {
 
 impl FromJwk for X25519KeyPair {
     fn from_jwk_parts(jwk: JwkParts<'_>) -> Result<Self, Error> {
+        if jwk.kty != JWK_KEY_TYPE {
+            return Err(err_msg!(InvalidKeyData, "Unsupported key type"));
+        }
+        if jwk.crv != JWK_CURVE {
+            return Err(err_msg!(InvalidKeyData, "Unsupported key algorithm"));
+        }
         ArrayKey::<U32>::temp(|pk_arr| {
             if jwk.x.decode_base64(pk_arr)? != pk_arr.len() {
                 Err(err_msg!(InvalidKeyData))
@@ -258,7 +264,7 @@ mod tests {
             .to_jwk_public(None)
             .expect("Error converting public key to JWK");
         let jwk = JwkParts::from_str(&jwk).expect("Error parsing JWK output");
-        assert_eq!(jwk.kty, "OKP");
+        assert_eq!(jwk.kty, JWK_KEY_TYPE);
         assert_eq!(jwk.crv, JWK_CURVE);
         assert_eq!(jwk.x, "tGskN_ae61DP4DLY31_fjkbvnKqf-ze7kA6Cj2vyQxU");
         assert_eq!(jwk.d, None);

--- a/askar-crypto/src/jwk/parts.rs
+++ b/askar-crypto/src/jwk/parts.rs
@@ -21,6 +21,8 @@ pub struct JwkParts<'a> {
     pub kty: &'a str,
     /// Key ID
     pub kid: OptAttr<'a>,
+    /// Key algorithm
+    pub alg: OptAttr<'a>,
     /// Curve type
     pub crv: OptAttr<'a>,
     /// Curve key public x coordinate
@@ -141,6 +143,7 @@ impl<'de> Visitor<'de> for JwkMapVisitor<'de> {
     {
         let mut kty = None;
         let mut kid = None;
+        let mut alg = None;
         let mut crv = None;
         let mut x = None;
         let mut y = None;
@@ -152,6 +155,7 @@ impl<'de> Visitor<'de> for JwkMapVisitor<'de> {
             match key {
                 "kty" => kty = Some(access.next_value()?),
                 "kid" => kid = Some(access.next_value()?),
+                "alg" => alg = Some(access.next_value()?),
                 "crv" => crv = Some(access.next_value()?),
                 "x" => x = Some(access.next_value()?),
                 "y" => y = Some(access.next_value()?),
@@ -178,6 +182,7 @@ impl<'de> Visitor<'de> for JwkMapVisitor<'de> {
             Ok(JwkParts {
                 kty,
                 kid: kid.into(),
+                alg: alg.into(),
                 crv: crv.into(),
                 x: x.into(),
                 y: y.into(),
@@ -206,6 +211,9 @@ impl Serialize for JwkParts<'_> {
         S: Serializer,
     {
         let mut map = serializer.serialize_map(None)?;
+        if let Some(alg) = self.alg.to_option() {
+            map.serialize_entry("alg", alg)?;
+        }
         if let Some(crv) = self.crv.to_option() {
             map.serialize_entry("crv", crv)?;
         }


### PR DESCRIPTION
Switches BLS keys to 'OKP' for the kty value - following https://github.com/mattrglobal/bls12381-jwk-draft
