### PR TITLE
Accept EC key type for BLS keys

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["askar-bbs", "askar-crypto"]
 
 [package]
 name = "aries-askar"
-version = "0.2.3"
+version = "0.2.4"
 authors = ["Hyperledger Aries Contributors <aries@lists.hyperledger.org>"]
 edition = "2018"
 description = "Hyperledger Aries Askar secure storage"
@@ -43,7 +43,7 @@ async-stream = "0.3"
 bs58 = "0.4"
 chrono = "0.4"
 digest = "0.10"
-env_logger = { version = "0.7", optional = true }
+env_logger = { version = "0.9", optional = true }
 ffi-support = { version = "0.4", optional = true }
 futures-lite = "1.11"
 hex = "0.4"

--- a/askar-crypto/Cargo.toml
+++ b/askar-crypto/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "askar-crypto"
-version = "0.2.3"
+version = "0.2.4"
 authors = ["Hyperledger Aries Contributors <aries@lists.hyperledger.org>"]
 edition = "2018"
 description = "Hyperledger Aries Askar cryptography"

--- a/askar-crypto/src/alg/any.rs
+++ b/askar-crypto/src/alg/any.rs
@@ -74,7 +74,7 @@ impl AnyKey {
     }
 
     #[inline]
-    fn key_type_id(&self) -> TypeId {
+    pub fn key_type_id(&self) -> TypeId {
         self.0.as_any().type_id()
     }
 }
@@ -524,11 +524,15 @@ fn from_jwk_any<R: AllocKey>(jwk: JwkParts<'_>) -> Result<R, Error> {
             X25519KeyPair::from_jwk_parts(jwk).map(R::alloc_key)
         }
         #[cfg(feature = "bls")]
-        ("OKP", c) if c == G1::JWK_CURVE => BlsKeyPair::<G1>::from_jwk_parts(jwk).map(R::alloc_key),
+        ("OKP" | "EC", c) if c == G1::JWK_CURVE => {
+            BlsKeyPair::<G1>::from_jwk_parts(jwk).map(R::alloc_key)
+        }
         #[cfg(feature = "bls")]
-        ("OKP", c) if c == G2::JWK_CURVE => BlsKeyPair::<G2>::from_jwk_parts(jwk).map(R::alloc_key),
+        ("OKP" | "EC", c) if c == G2::JWK_CURVE => {
+            BlsKeyPair::<G2>::from_jwk_parts(jwk).map(R::alloc_key)
+        }
         #[cfg(feature = "bls")]
-        ("OKP", c) if c == G1G2::JWK_CURVE => {
+        ("OKP" | "EC", c) if c == G1G2::JWK_CURVE => {
             BlsKeyPair::<G1G2>::from_jwk_parts(jwk).map(R::alloc_key)
         }
         #[cfg(feature = "k256")]

--- a/src/ffi/error.rs
+++ b/src/ffi/error.rs
@@ -10,7 +10,7 @@ use once_cell::sync::Lazy;
 static LAST_ERROR: Lazy<RwLock<Option<Error>>> = Lazy::new(|| RwLock::new(None));
 
 #[derive(Debug, PartialEq, Copy, Clone, Serialize)]
-#[repr(usize)]
+#[repr(i64)]
 pub enum ErrorCode {
     Success = 0,
     Backend = 1,

--- a/wrappers/python/aries_askar/bindings.py
+++ b/wrappers/python/aries_askar/bindings.py
@@ -526,6 +526,7 @@ def _create_callback(cb_type: CFUNCTYPE, fut: asyncio.Future, post_process=None)
 def do_call(fn_name, *args):
     """Perform a synchronous library function call."""
     lib_fn = getattr(get_library(), fn_name)
+    lib_fn.restype = c_int64
     result = lib_fn(*args)
     if result:
         raise get_current_error(True)
@@ -536,6 +537,7 @@ def do_call_async(
 ) -> asyncio.Future:
     """Perform an asynchronous library function call."""
     lib_fn = getattr(get_library(), fn_name)
+    lib_fn.restype = c_int64
     loop = asyncio.get_event_loop()
     fut = loop.create_future()
     cf_args = [None, c_int64, c_int64]

--- a/wrappers/python/aries_askar/version.py
+++ b/wrappers/python/aries_askar/version.py
@@ -1,3 +1,3 @@
 """aries_askar library wrapper version."""
 
-__version__ = "0.2.3"
+__version__ = "0.2.4"


### PR DESCRIPTION
Consistent with previous specifications, although OKP is preferred (EC keys tend to have both `x` and `y` components).

Updates env_logger to 0.9.

Updates library version to 0.2.4.