### PR TITLE
fix: get_jwk_secret returning string of byte buffer

### DIFF
--- a/wrappers/python/aries_askar/key.py
+++ b/wrappers/python/aries_askar/key.py
@@ -69,8 +69,8 @@ class Key:
     def get_jwk_public(self, alg: Union[str, KeyAlg] = None) -> str:
         return bindings.key_get_jwk_public(self._handle, alg)
 
-    def get_jwk_secret(self) -> str:
-        return str(bindings.key_get_jwk_secret(self._handle))
+    def get_jwk_secret(self) -> bytes:
+        return bytes(bindings.key_get_jwk_secret(self._handle))
 
     def get_jwk_thumbprint(self, alg: Union[str, KeyAlg] = None) -> str:
         return bindings.key_get_jwk_thumbprint(self._handle, alg)

--- a/wrappers/python/tests/test_keys.py
+++ b/wrappers/python/tests/test_keys.py
@@ -73,3 +73,7 @@ def test_ed25519():
     jwk = json.loads(key.get_jwk_public())
     assert jwk["kty"] == "OKP"
     assert jwk["crv"] == "Ed25519"
+
+    jwk = json.loads(key.get_jwk_secret())
+    assert jwk["kty"] == "OKP"
+    assert jwk["crv"] == "Ed25519"


### PR DESCRIPTION
Python wrapper is currently inappropriately returning the value generated by `Key.get_jwk_secret()`:
```
>>> key = Key.generate(KeyAlg.ED25519)
>>> key.get_jwk_secret()
'ByteBuffer(b\'{"crv":"Ed25519","kty":"OKP","x":"ZznCDr5B3BHGd7MHm8TEFIFhkqqaPbbhXkTDDzgRD1s","d":"ev2R0MyiIGzEw5UmSc83gxpBf808PLRIWbqZ481_w3A"}\')'
```

This PR adds a quick fix and a simple test.