### PR TITLE
feat: auto commit txn on aexit

### DIFF
--- a/wrappers/python/aries_askar/store.py
+++ b/wrappers/python/aries_askar/store.py
@@ -626,4 +626,11 @@ class OpenSession:
     async def __aexit__(self, exc_type, exc, tb):
         session = self._session
         self._session = None
+
+        if session.is_transaction and session.handle:
+            if exc:
+                await session.rollback()
+            else:
+                await session.commit()
+
         await session.close()


### PR DESCRIPTION
This is an attempt to visualize what #51 would look like. I think it's this simple?

As implemented, instead of an effective "rollback by default", it will rollback if the transaction exits with an exception but otherwise commit by default. The user may still choose to manually call `rollback` before the context is exited.