### PR TITLE
shrink unsafe block

### DIFF
--- a/src/ffi/handle.rs
+++ b/src/ffi/handle.rs
@@ -18,7 +18,7 @@ impl<T: Send> ArcHandle<T> {
     pub fn load(&self) -> Result<Arc<T>, Error> {
         self.validate()?;
         
-            let result = unsafe { mem::ManuallyDrop::new(Arc::from_raw(self.0)) };
+            let result = mem::ManuallyDrop::new(unsafe { Arc::from_raw(self.0) });
             Ok((&*result).clone())
         
     }

--- a/src/ffi/handle.rs
+++ b/src/ffi/handle.rs
@@ -17,10 +17,10 @@ impl<T: Send> ArcHandle<T> {
 
     pub fn load(&self) -> Result<Arc<T>, Error> {
         self.validate()?;
-        unsafe {
-            let result = mem::ManuallyDrop::new(Arc::from_raw(self.0));
+        
+            let result = unsafe { mem::ManuallyDrop::new(Arc::from_raw(self.0)) };
             Ok((&*result).clone())
-        }
+        
     }
 
     pub fn remove(&self) {

--- a/src/ffi/handle.rs
+++ b/src/ffi/handle.rs
@@ -16,10 +16,9 @@ impl<T: Send> ArcHandle<T> {
     }
 
     pub fn load(&self) -> Result<Arc<T>, Error> {
-        self.validate()?;
-        
-            let result = mem::ManuallyDrop::new(unsafe { Arc::from_raw(self.0) });
-            Ok((&*result).clone())
+        self.validate()?;        
+        let result = mem::ManuallyDrop::new(unsafe { Arc::from_raw(self.0) });
+        Ok((&*result).clone())
         
     }
 


### PR DESCRIPTION
In this function you use the unsafe keyword for some safe expressions. However, I found that only 1 function are real unsafe operations (see the list below). 

We need to mark unsafe operations more precisely using unsafe keyword. Keeping unsafe blocks small can bring many benefits. For example, when mistakes happen, we can locate any errors related to memory safety  within an unsafe block. This is the balance between Safe and Unsafe Rust. The separation is designed to make using Safe Rust as ergonomic as possible, but requires extra effort and care when writing Unsafe Rust. 
**Real unsafe operation list:**
1. the from_raw() function(unsafe function)

Hope this PR can help you.
Best regards.
**References**
https://doc.rust-lang.org/nomicon/safe-unsafe-meaning.html 
https://doc.rust-lang.org/book/ch19-01-unsafe-rust.html 