### PR TITLE
feat: add include to index so some operations don't need to access th…

### DIFF
--- a/src/backend/postgres/provision.rs
+++ b/src/backend/postgres/provision.rs
@@ -341,8 +341,8 @@ pub(crate) async fn init_db<'t>(
                 ON DELETE CASCADE ON UPDATE CASCADE
         );
         CREATE INDEX ix_items_tags_item_id ON items_tags(item_id);
-        CREATE INDEX ix_items_tags_name_enc ON items_tags(name, SUBSTR(value, 1, 12)) WHERE plaintext=0;
-        CREATE INDEX ix_items_tags_name_plain ON items_tags(name, value) WHERE plaintext=1;
+        CREATE INDEX ix_items_tags_name_enc ON items_tags(name, SUBSTR(value, 1, 12)) include (item_id) WHERE plaintext=0;
+        CREATE INDEX ix_items_tags_name_plain ON items_tags(name, value) include (item_id) WHERE plaintext=1;
     ",
     )
     .await?;


### PR DESCRIPTION
We found that this change improves performance when there are a large number of records in the database. With a small number of records, it doesn't appear to impact performance.

Signed-off-by: Kim Ebert <kim@indicio.tech>