### PR TITLE
Exposed Argon enum in Rust to use it for key derivation

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -48,7 +48,11 @@ mod ffi;
 pub mod kms;
 
 mod protect;
-pub use protect::{generate_raw_store_key, PassKey, StoreKeyMethod};
+pub use protect::{
+    generate_raw_store_key,
+    kdf::{Argon2Level, KdfMethod},
+    PassKey, StoreKeyMethod,
+};
 
 mod storage;
 pub use storage::{Entry, EntryTag, Scan, Store, TagFilter};

--- a/src/protect/kdf/argon2.rs
+++ b/src/protect/kdf/argon2.rs
@@ -15,9 +15,12 @@ pub use crate::crypto::kdf::argon2::SaltSize;
 pub const LEVEL_INTERACTIVE: &'static str = "13:int";
 pub const LEVEL_MODERATE: &'static str = "13:mod";
 
+/// Argon2i derivation methods
 #[derive(Copy, Clone, Debug, PartialEq, Eq, Hash)]
 pub enum Level {
+    /// Interactive method
     Interactive,
+    /// Stronger Moderate method
     Moderate,
 }
 
@@ -28,7 +31,7 @@ impl Default for Level {
 }
 
 impl Level {
-    pub fn from_str(level: &str) -> Option<Self> {
+    pub(crate) fn from_str(level: &str) -> Option<Self> {
         match level {
             "int" | LEVEL_INTERACTIVE => Some(Self::Interactive),
             "mod" | LEVEL_MODERATE => Some(Self::Moderate),
@@ -37,14 +40,14 @@ impl Level {
         }
     }
 
-    pub fn as_str(&self) -> &'static str {
+    pub(crate) fn as_str(&self) -> &'static str {
         match self {
             Self::Interactive => LEVEL_INTERACTIVE,
             Self::Moderate => LEVEL_MODERATE,
         }
     }
 
-    pub fn generate_salt(&self) -> ArrayKey<SaltSize> {
+    pub(crate) fn generate_salt(&self) -> ArrayKey<SaltSize> {
         ArrayKey::random()
     }
 
@@ -55,7 +58,7 @@ impl Level {
         }
     }
 
-    pub fn derive_key(&self, password: &[u8], salt: &[u8]) -> Result<StoreKey, Error> {
+    pub(crate) fn derive_key(&self, password: &[u8], salt: &[u8]) -> Result<StoreKey, Error> {
         ArrayKey::<<StoreKeyType as KeyMeta>::KeySize>::temp(|key| {
             Argon2::new(password, salt, *self.params())?.derive_key_bytes(key)?;
             Ok(StoreKey::from(StoreKeyType::from_secret_bytes(&*key)?))

--- a/src/protect/kdf/mod.rs
+++ b/src/protect/kdf/mod.rs
@@ -6,17 +6,20 @@ use crate::{
 };
 
 mod argon2;
-use self::argon2::{Level as Argon2Level, SaltSize as Argon2Salt};
+pub use self::argon2::Level as Argon2Level;
+use self::argon2::SaltSize as Argon2Salt;
 
 pub const METHOD_ARGON2I: &'static str = "argon2i";
 
+/// Supported KDF methods for generating or referencing a store key
 #[derive(Copy, Clone, Debug, PartialEq, Eq, Hash)]
 pub enum KdfMethod {
+    /// Argon2i derivation method
     Argon2i(Argon2Level),
 }
 
 impl KdfMethod {
-    pub fn from_str(method: &str) -> Option<(Self, String)> {
+    pub(crate) fn from_str(method: &str) -> Option<(Self, String)> {
         let mut method_and_detail = method.splitn(3, ':');
         let prefix = method_and_detail.next();
         if prefix != Some(PREFIX_KDF) {
@@ -45,7 +48,7 @@ impl KdfMethod {
         }
     }
 
-    pub fn to_string(&self, detail: Option<&str>) -> String {
+    pub(crate) fn to_string(&self, detail: Option<&str>) -> String {
         match self {
             Self::Argon2i(level) => format!(
                 "{}:{}:{}{}",
@@ -57,7 +60,7 @@ impl KdfMethod {
         }
     }
 
-    pub fn derive_new_key(&self, password: &str) -> Result<(StoreKey, String), Error> {
+    pub(crate) fn derive_new_key(&self, password: &str) -> Result<(StoreKey, String), Error> {
         match self {
             Self::Argon2i(level) => {
                 let salt = level.generate_salt();
@@ -68,7 +71,7 @@ impl KdfMethod {
         }
     }
 
-    pub fn derive_key(&self, password: &str, detail: &str) -> Result<StoreKey, Error> {
+    pub(crate) fn derive_key(&self, password: &str, detail: &str) -> Result<StoreKey, Error> {
         match self {
             Self::Argon2i(level) => {
                 let salt = parse_salt::<Argon2Salt>(detail)?;


### PR DESCRIPTION
Askar exposes `StoreKeyMethod` enum (it is used for wallet creation and opening) but for using `DeriveKey` variant we need to pass `KdfMethod` object which is crate private. 