### PR TITLE
fix(js): set scan offset to 0 if not defined

### DIFF
--- a/wrappers/javascript/aries-askar-nodejs/src/NodeJSAriesAskar.ts
+++ b/wrappers/javascript/aries-askar-nodejs/src/NodeJSAriesAskar.ts
@@ -687,7 +687,7 @@ export class NodeJSAriesAskar implements AriesAskar {
           profile,
           category,
           tagFilter,
-          +offset || -1,
+          +offset || 0,
           +limit || -1,
           cb,
           cbId

--- a/wrappers/javascript/aries-askar-react-native/src/ReactNativeAriesAskar.ts
+++ b/wrappers/javascript/aries-askar-react-native/src/ReactNativeAriesAskar.ts
@@ -420,8 +420,8 @@ export class ReactNativeAriesAskar implements AriesAskar {
         cb,
         category,
         storeHandle,
+        offset: offset || 0,
         limit: limit || -1,
-        offset: offset || -1,
         profile,
         tagFilter,
       })


### PR DESCRIPTION
For some reason, JS wrappers were defaulting offset to -1. This throws an `OFFSET must not be negative` error when using a PostgreSQL backend.