### PR TITLE
feat(js): add Bls12381G1G2 to supported key algos

### DIFF
--- a/wrappers/javascript/aries-askar-nodejs/tests/keys.test.ts
+++ b/wrappers/javascript/aries-askar-nodejs/tests/keys.test.ts
@@ -1,4 +1,4 @@
-import { Key, KeyAlgs } from 'aries-askar-shared'
+import { Key, KeyAlgs, KeyMethod } from 'aries-askar-shared'
 
 import { setup } from './utils'
 
@@ -38,6 +38,17 @@ describe('keys', () => {
       crv: 'BLS12381_G1',
       kty: 'OKP',
       x: 'hsjb9FSBUJXuB1fCluEcUBLeAPgIbnZGfxPKyeN3LVjQaKFWzXfNtMFAY8VL-eu-',
+    })
+  })
+
+  test('Bls G1G2 Keygen', () => {
+    const seed = Uint8Array.from(Buffer.from('testseed000000000000000000000001'))
+    const key = Key.fromSeed({ algorithm: KeyAlgs.Bls12381G1G2, seed, method: KeyMethod.BlsKeygen })
+
+    expect(key.jwkPublic).toMatchObject({
+      crv: 'BLS12381_G1G2',
+      kty: 'OKP',
+      x: 'h56eYI8Qkq5hitICb-ik8wRTzcn6Fd4iY8aDNVc9q1xoPS3lh4DB_B4wNtar1HrViZIOsO6BgLV72zCrBE2ym3DEhDYcghnUMO4O8IVVD8yS-C_zu6OA3L-ny-AO4rbkAo-WuApZEjn83LY98UtoKpTufn4PCUFVQZzJNH_gXWHR3oDspJaCbOajBfm5qj6d',
     })
   })
 

--- a/wrappers/javascript/aries-askar-shared/src/enums/KeyAlgs.ts
+++ b/wrappers/javascript/aries-askar-shared/src/enums/KeyAlgs.ts
@@ -9,6 +9,7 @@ export enum KeyAlgs {
   AesA256Kw = 'a256kw',
   Bls12381G1 = 'bls12381g1',
   Bls12381G2 = 'bls12381g2',
+  Bls12381G1G2 = 'bls12381g1g2',
   Chacha20C20P = 'c20p',
   Chacha20XC20P = 'xc20p',
   Ed25519 = 'ed25519',


### PR DESCRIPTION
G1G2 variant of BLS12381 is supported by Askar but is not available in JavaScript wrappers. In this PR we add the constant to `KeyAlgs` enum.