### PR TITLE
Add FFI method to terminate worker threads; fix custom logger disabling

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,6 +38,7 @@ pg_test = ["postgres"]
 hex-literal = "0.3"
 
 [dependencies]
+arc-swap = "1.6"
 async-lock = "2.5"
 async-stream = "0.3"
 bs58 = "0.4"
@@ -77,8 +78,8 @@ features = ["chrono", "runtime-tokio-rustls"]
 optional = true
 
 [profile.release]
-lto = true
 codegen-units = 1
+lto = true
 
 [[test]]
 name = "backends"

--- a/src/ffi/handle.rs
+++ b/src/ffi/handle.rs
@@ -17,15 +17,13 @@ impl<T: Send> ArcHandle<T> {
 
     pub fn load(&self) -> Result<Arc<T>, Error> {
         self.validate()?;
-        unsafe {
-            let result = mem::ManuallyDrop::new(Arc::from_raw(self.0));
-            Ok((&*result).clone())
-        }
+        let result = unsafe { mem::ManuallyDrop::new(Arc::from_raw(self.0)) };
+        Ok((&*result).clone())
     }
 
     pub fn remove(&self) {
-        unsafe {
-            if !self.0.is_null() {
+        if !self.0.is_null() {
+            unsafe {
                 // Drop the initial reference. There could be others outstanding.
                 Arc::decrement_strong_count(self.0);
             }

--- a/src/ffi/log.rs
+++ b/src/ffi/log.rs
@@ -50,13 +50,13 @@ impl CustomLogger {
     }
 
     fn disable(&self) {
-        self.disabled.store(false, Ordering::Release);
+        self.disabled.store(true, Ordering::Release);
     }
 }
 
 impl log::Log for CustomLogger {
     fn enabled(&self, metadata: &Metadata<'_>) -> bool {
-        if !self.disabled.load(Ordering::Acquire) {
+        if self.disabled.load(Ordering::Acquire) {
             false
         } else if let Some(enabled_cb) = self.enabled {
             enabled_cb(self.context, metadata.level() as i32) != 0
@@ -66,6 +66,10 @@ impl log::Log for CustomLogger {
     }
 
     fn log(&self, record: &Record<'_>) {
+        if !self.enabled(record.metadata()) {
+            return;
+        }
+
         let log_cb = self.log;
 
         let level = record.level() as i32;

--- a/src/ffi/mod.rs
+++ b/src/ffi/mod.rs
@@ -1,5 +1,6 @@
 use std::marker::PhantomData;
 use std::os::raw::c_char;
+use std::time::Duration;
 
 use ffi_support::rust_string_to_c;
 
@@ -58,6 +59,11 @@ impl<T, F: Fn(Result<T, Error>)> Drop for EnsureCallback<T, F> {
             (self.f)(Err(err_msg!(Unexpected)));
         }
     }
+}
+
+#[no_mangle]
+pub extern "C" fn askar_terminate() {
+    crate::future::shutdown(Duration::from_secs(5));
 }
 
 #[no_mangle]

--- a/src/future.rs
+++ b/src/future.rs
@@ -1,15 +1,30 @@
-use std::{future::Future, pin::Pin, time::Duration};
+use std::{
+    future::Future,
+    pin::Pin,
+    sync::Arc,
+    thread,
+    time::{Duration, Instant},
+};
 
+use arc_swap::ArcSwapOption;
 use once_cell::sync::Lazy;
 use tokio::runtime::Runtime;
 
 pub type BoxFuture<'a, T> = Pin<Box<dyn Future<Output = T> + Send + 'a>>;
 
-static RUNTIME: Lazy<Runtime> = Lazy::new(|| Runtime::new().expect("Error creating tokio runtime"));
+static RUNTIME: Lazy<ArcSwapOption<Runtime>> = Lazy::new(|| {
+    ArcSwapOption::new(Some(Arc::new(
+        Runtime::new().expect("Error creating tokio runtime"),
+    )))
+});
 
 /// Block the current thread on an async task, when not running inside the scheduler.
 pub fn block_on<R>(f: impl Future<Output = R>) -> R {
-    RUNTIME.block_on(f)
+    if let Some(rt) = RUNTIME.load().clone() {
+        rt.block_on(f)
+    } else {
+        panic!("Runtime has been shut down");
+    }
 }
 
 /// Run a blocking task without interrupting the async scheduler.
@@ -19,28 +34,64 @@ where
     T: Send + 'static,
     F: FnOnce() -> T + Send + 'static,
 {
-    RUNTIME
-        .spawn_blocking(f)
-        .await
-        .expect("Error running blocking task")
+    if let Some(rt) = RUNTIME.load().clone() {
+        rt.spawn_blocking(f)
+            .await
+            .expect("Error running blocking task")
+    } else {
+        panic!("Runtime has been shut down");
+    }
 }
 
 /// Spawn an async task into the runtime.
 #[inline]
 pub fn spawn_ok(fut: impl Future<Output = ()> + Send + 'static) {
-    RUNTIME.spawn(fut);
+    if let Some(rt) = RUNTIME.load().clone() {
+        rt.spawn(fut);
+    }
 }
 
 /// Wait until a specific duration has passed (used in tests).
 #[doc(hidden)]
 pub async fn sleep(dur: Duration) {
-    let _rt = RUNTIME.enter();
-    tokio::time::sleep(dur).await
+    if let Some(rt) = RUNTIME.load().clone() {
+        let _rt = rt.enter();
+        tokio::time::sleep(dur).await
+    }
 }
 
 /// Cancel an async task if it does not complete after a timeout (used in tests).
 #[doc(hidden)]
 pub async fn timeout<R>(dur: Duration, f: impl Future<Output = R>) -> Option<R> {
-    let _rt = RUNTIME.enter();
-    tokio::time::timeout(dur, f).await.ok()
+    if let Some(rt) = RUNTIME.load().clone() {
+        let _rt = rt.enter();
+        tokio::time::timeout(dur, f).await.ok()
+    } else {
+        None
+    }
+}
+
+/// Shut down the async runtime.
+#[doc(hidden)]
+pub fn shutdown(max_dur: Duration) {
+    let start = Instant::now();
+    if let Some(rt_swap) = Lazy::get(&RUNTIME) {
+        if let Some(mut rt) = rt_swap.swap(None) {
+            loop {
+                match Arc::try_unwrap(rt) {
+                    Ok(rt) => {
+                        rt.shutdown_timeout(max_dur.saturating_sub(start.elapsed()));
+                        break;
+                    }
+                    Err(new_rt) => {
+                        rt = new_rt;
+                        if start.elapsed() >= max_dur {
+                            break;
+                        }
+                        thread::sleep(Duration::from_millis(1));
+                    }
+                }
+            }
+        }
+    }
 }

--- a/wrappers/python/aries_askar/bindings/__init__.py
+++ b/wrappers/python/aries_askar/bindings/__init__.py
@@ -3,9 +3,8 @@
 import asyncio
 import json
 import logging
-import sys
 
-from ctypes import POINTER, byref, c_char_p, c_int8, c_int32, c_int64
+from ctypes import POINTER, byref, c_int8, c_int32, c_int64
 from typing import Optional, Union
 
 from ..types import EntryOperation, KeyAlg, SeedMethod

--- a/wrappers/python/aries_askar/bindings/lib.py
+++ b/wrappers/python/aries_askar/bindings/lib.py
@@ -210,7 +210,9 @@ class LibLoad:
         if result:
             raise self.get_current_error(True)
 
-    def invoke_async(self, name: str, argtypes, *args, return_type=None):
+    def invoke_async(
+        self, name: str, argtypes, *args, return_type=None
+    ) -> asyncio.Future:
         """Perform an asynchronous library function call."""
         method = self.method(name, (*argtypes, c_void_p, c_int64), restype=c_int64)
         loop = asyncio.get_event_loop()
@@ -315,6 +317,8 @@ class LibLoad:
                     "%s: Timed out waiting for callbacks to complete",
                     self._lib_name,
                 )
+
+        self.method("askar_terminate", None, restype=None)()
 
 
 class Lib:

--- a/wrappers/python/aries_askar/store.py
+++ b/wrappers/python/aries_askar/store.py
@@ -3,13 +3,11 @@
 import json
 
 from typing import Optional, Sequence, Union
-from weakref import ref
 
 from cached_property import cached_property
 
 from . import bindings
 from .bindings import (
-    ByteBuffer,
     EntryListHandle,
     KeyEntryListHandle,
     ScanHandle,


### PR DESCRIPTION
In my tests this appears to fix the intermittent failures when terminating after running the Python wrapper tests.