### PR TITLE
fix(js): free key and entry objects

### DIFF
--- a/wrappers/javascript/aries-askar-nodejs/src/NodeJSAriesAskar.ts
+++ b/wrappers/javascript/aries-askar-nodejs/src/NodeJSAriesAskar.ts
@@ -484,9 +484,9 @@ export class NodeJSAriesAskar implements AriesAskar {
   }
 
   public keyFree(options: KeyFreeOptions): void {
-    const { keyEntryListHandle } = serializeArguments(options)
+    const { keyHandle } = serializeArguments(options)
 
-    nativeAriesAskar.askar_key_free(keyEntryListHandle)
+    nativeAriesAskar.askar_key_free(keyHandle)
     handleError()
   }
 

--- a/wrappers/javascript/aries-askar-nodejs/tests/cryptoBox.test.ts
+++ b/wrappers/javascript/aries-askar-nodejs/tests/cryptoBox.test.ts
@@ -13,5 +13,6 @@ describe('CryptoBox', () => {
 
     const opened = CryptoBox.sealOpen({ recipientKey: x25519Key, ciphertext: sealed })
     expect(opened).toStrictEqual(message)
+    x25519Key.handle.free()
   })
 })

--- a/wrappers/javascript/aries-askar-nodejs/tests/joseEcdh.test.ts
+++ b/wrappers/javascript/aries-askar-nodejs/tests/joseEcdh.test.ts
@@ -54,6 +54,8 @@ describe('jose ecdh', () => {
       aad: Uint8Array.from(Buffer.from(protectedB64)),
     })
     expect(Buffer.from(messageReceived).toString()).toStrictEqual(messageString)
+    ephemeralKey.handle.free()
+    bobKey.handle.free()
   })
 
   test('ecdh es wrapped', () => {
@@ -108,6 +110,10 @@ describe('jose ecdh', () => {
     const messageReceived = cekReceiver.aeadDecrypt({ ciphertext, tag, nonce, aad: protectedB64Bytes })
 
     expect(messageReceived).toStrictEqual(message)
+    ephemeralKey.handle.free()
+    bobKey.handle.free()
+    cek.handle.free()
+    cekReceiver.handle.free()
   })
 
   test('ecdh 1pu direct', () => {
@@ -164,6 +170,9 @@ describe('jose ecdh', () => {
     })
 
     expect(messageReceived).toStrictEqual(message)
+    aliceKey.handle.free()
+    bobKey.handle.free()
+    ephemeralKey.handle.free()
   })
 
   /**
@@ -319,5 +328,9 @@ describe('jose ecdh', () => {
     })
 
     expect(cekReceiver2.jwkSecret).toStrictEqual(cek.jwkSecret)
+    cek.handle.free()
+    cekReceiver.handle.free()
+    cekReceiver2.handle.free()
+    derived.handle.free()
   })
 })

--- a/wrappers/javascript/aries-askar-nodejs/tests/store.test.ts
+++ b/wrappers/javascript/aries-askar-nodejs/tests/store.test.ts
@@ -157,21 +157,22 @@ describe('Store and Session', () => {
 
     await session.insertKey({ key, name: keyName, metadata: 'metadata', tags: { a: 'b' } })
 
-    await expect(session.fetchKey({ name: keyName })).resolves.toMatchObject({
+    const fetchedKey1 = await session.fetchKey({ name: keyName })
+    expect(fetchedKey1).toMatchObject({
       name: keyName,
       tags: { a: 'b' },
       metadata: 'metadata',
     })
 
     await session.updateKey({ name: keyName, metadata: 'updated metadata', tags: { a: 'c' } })
-    const fetchedKey = await session.fetchKey({ name: keyName })
-    expect(fetchedKey).toMatchObject({
+    const fetchedKey2 = await session.fetchKey({ name: keyName })
+    expect(fetchedKey2).toMatchObject({
       name: keyName,
       tags: { a: 'c' },
       metadata: 'updated metadata',
     })
 
-    expect(key.jwkThumbprint === fetchedKey.key.jwkThumbprint).toBeTruthy()
+    expect(key.jwkThumbprint === fetchedKey1.key.jwkThumbprint).toBeTruthy()
 
     const found = await session.fetchAllKeys({
       algorithm: KeyAlgs.Ed25519,
@@ -186,6 +187,12 @@ describe('Store and Session', () => {
     await expect(session.fetchKey({ name: keyName })).rejects.toThrowError(AriesAskarError)
 
     await session.close()
+
+    // Clear objects
+    fetchedKey1.key.handle.free()
+    fetchedKey2.key.handle.free()
+    key.handle.free()
+    found.forEach((entry) => entry.key.handle.free())
   })
 
   test('profile', async () => {

--- a/wrappers/javascript/aries-askar-shared/src/ariesAskar/AriesAskar.ts
+++ b/wrappers/javascript/aries-askar-shared/src/ariesAskar/AriesAskar.ts
@@ -96,7 +96,7 @@ export type KeyEntryListGetMetadataOptions = { keyEntryListHandle: KeyEntryListH
 export type KeyEntryListGetNameOptions = { keyEntryListHandle: KeyEntryListHandle; index: number }
 export type KeyEntryListGetTagsOptions = { keyEntryListHandle: KeyEntryListHandle; index: number }
 export type KeyEntryListLoadLocalOptions = { keyEntryListHandle: KeyEntryListHandle; index: number }
-export type KeyFreeOptions = { keyEntryListHandle: KeyEntryListHandle }
+export type KeyFreeOptions = { keyHandle: LocalKeyHandle }
 export type KeyFromJwkOptions = { jwk: Jwk }
 export type KeyFromKeyExchangeOptions = {
   algorithm: KeyAlgs

--- a/wrappers/javascript/aries-askar-shared/src/crypto/Ecdh1PU.ts
+++ b/wrappers/javascript/aries-askar-shared/src/crypto/Ecdh1PU.ts
@@ -64,7 +64,9 @@ export class Ecdh1PU {
     nonce?: Uint8Array
   }) {
     const derived = this.deriveKey({ encAlg, ephemeralKey, recipientKey, senderKey, receive: false })
-    return derived.aeadEncrypt({ message, aad, nonce })
+    const encryptedBuffer = derived.aeadEncrypt({ message, aad, nonce })
+    derived.handle.free()
+    return encryptedBuffer
   }
 
   public decryptDirect({
@@ -87,7 +89,9 @@ export class Ecdh1PU {
     aad?: Uint8Array
   }) {
     const derived = this.deriveKey({ encAlg, ephemeralKey, recipientKey, senderKey, receive: true })
-    return derived.aeadDecrypt({ tag, nonce, ciphertext, aad })
+    const encryptedBuffer = derived.aeadDecrypt({ tag, nonce, ciphertext, aad })
+    derived.handle.free()
+    return encryptedBuffer
   }
 
   public senderWrapKey({
@@ -113,7 +117,9 @@ export class Ecdh1PU {
       receive: false,
       ccTag,
     })
-    return derived.wrapKey({ other: cek })
+    const encryptedBuffer = derived.wrapKey({ other: cek })
+    derived.handle.free()
+    return encryptedBuffer
   }
 
   public receiverUnwrapKey({
@@ -145,6 +151,8 @@ export class Ecdh1PU {
       senderKey,
       ccTag,
     })
-    return derived.unwrapKey({ tag, nonce, ciphertext, algorithm: encAlg })
+    const encryptedBuffer = derived.unwrapKey({ tag, nonce, ciphertext, algorithm: encAlg })
+    derived.handle.free()
+    return encryptedBuffer
   }
 }

--- a/wrappers/javascript/aries-askar-shared/src/crypto/EcdhEs.ts
+++ b/wrappers/javascript/aries-askar-shared/src/crypto/EcdhEs.ts
@@ -59,7 +59,9 @@ export class EcdhEs {
     const eKey = ephemeralKey instanceof Jwk ? Key.fromJwk({ jwk: ephemeralKey }) : ephemeralKey
     const rKey = recipientKey instanceof Jwk ? Key.fromJwk({ jwk: recipientKey }) : recipientKey
     const derived = this.deriveKey({ encAlg, ephemeralKey: eKey, recipientKey: rKey, receive: false })
-    return derived.aeadEncrypt({ message, aad, nonce })
+    const encryptedBuffer = derived.aeadEncrypt({ message, aad, nonce })
+    derived.handle.free()
+    return encryptedBuffer
   }
 
   public decryptDirect({
@@ -82,7 +84,9 @@ export class EcdhEs {
     const eKey = ephemeralKey instanceof Jwk ? Key.fromJwk({ jwk: ephemeralKey }) : ephemeralKey
     const rKey = recipientKey instanceof Jwk ? Key.fromJwk({ jwk: recipientKey }) : recipientKey
     const derived = this.deriveKey({ encAlg, ephemeralKey: eKey, recipientKey: rKey, receive: true })
-    return derived.aeadDecrypt({ tag, nonce, ciphertext, aad })
+    const encryptedBuffer = derived.aeadDecrypt({ tag, nonce, ciphertext, aad })
+    derived.handle.free()
+    return encryptedBuffer
   }
 
   public senderWrapKey({
@@ -97,7 +101,9 @@ export class EcdhEs {
     cek: Key
   }) {
     const derived = this.deriveKey({ encAlg: wrapAlg, ephemeralKey, recipientKey, receive: false })
-    return derived.wrapKey({ other: cek })
+    const encryptedBuffer = derived.wrapKey({ other: cek })
+    derived.handle.free()
+    return encryptedBuffer
   }
 
   public receiverUnwrapKey({
@@ -118,6 +124,8 @@ export class EcdhEs {
     tag?: Uint8Array
   }) {
     const derived = this.deriveKey({ encAlg: wrapAlg, ephemeralKey, recipientKey, receive: true })
-    return derived.unwrapKey({ tag, nonce, ciphertext, algorithm: encAlg })
+    const encryptedBuffer = derived.unwrapKey({ tag, nonce, ciphertext, algorithm: encAlg })
+    derived.handle.free()
+    return encryptedBuffer
   }
 }

--- a/wrappers/javascript/aries-askar-shared/src/crypto/handles.ts
+++ b/wrappers/javascript/aries-askar-shared/src/crypto/handles.ts
@@ -66,6 +66,10 @@ export class EntryListHandle extends ArcHandle {
   public getTags(index: number) {
     return ariesAskar.entryListGetTags({ index, entryListHandle: this })
   }
+
+  public free() {
+    ariesAskar.entryListFree({ entryListHandle: this })
+  }
 }
 
 export class KeyEntryListHandle extends ArcHandle {
@@ -88,6 +92,14 @@ export class KeyEntryListHandle extends ArcHandle {
   public loadKey(index: number) {
     return ariesAskar.keyEntryListLoadLocal({ index, keyEntryListHandle: this })
   }
+
+  public free() {
+    ariesAskar.keyEntryListFree({ keyEntryListHandle: this })
+  }
 }
 
-export class LocalKeyHandle extends ArcHandle {}
+export class LocalKeyHandle extends ArcHandle {
+  public free() {
+    ariesAskar.keyFree({ keyHandle: this })
+  }
+}

--- a/wrappers/javascript/aries-askar-shared/src/store/Session.ts
+++ b/wrappers/javascript/aries-askar-shared/src/store/Session.ts
@@ -48,8 +48,11 @@ export class Session {
     if (!handle) return undefined
 
     const entry = new Entry({ list: handle, position: 0 })
+    const entryObject = entry.toJson(isJson)
 
-    return entry.toJson(isJson)
+    handle.free()
+
+    return entryObject
   }
 
   public async fetchAll({
@@ -72,8 +75,11 @@ export class Session {
       category,
     })
     const entryList = new EntryList({ handle })
+    const entryObjects = entryList.toArray()
 
-    return entryList.toArray()
+    entryList.handle.free()
+
+    return entryObjects
   }
 
   public async insert({
@@ -192,7 +198,11 @@ export class Session {
     if (!this.handle) throw AriesAskarError.customError({ message: 'Cannot fetch a key with a closed session' })
     const handle = await ariesAskar.sessionFetchKey({ forUpdate, name, sessionHandle: this.handle })
     const keyEntryList = new KeyEntryList({ handle })
-    return keyEntryList.getEntryByIndex(0).toJson()
+    const keyEntryObject = keyEntryList.getEntryByIndex(0).toJson()
+
+    keyEntryList.handle.free()
+
+    return keyEntryObject
   }
 
   public async fetchAllKeys({
@@ -219,7 +229,10 @@ export class Session {
     })
 
     const keyEntryList = new KeyEntryList({ handle })
-    return keyEntryList.toArray()
+    const keyEntryObjects = keyEntryList.toArray()
+    keyEntryList.handle.free()
+
+    return keyEntryObjects
   }
 
   public async updateKey({


### PR DESCRIPTION
As there is not a destructor in JS, objects must be freed manually. This PR attempts to free any native object after it is used, making life easier to consumer applications. 

If this approach is correct, the only objects an app using this library should care about is `Key` (for which I added the missing call to `keyFree`).

@blu3beri let me know if concepts applied here are correct so I can replicate for anoncreds-rs.