### PR TITLE
fix(js): ensure scan is freed after fetchAll

### DIFF
--- a/wrappers/javascript/aries-askar-shared/src/store/Scan.ts
+++ b/wrappers/javascript/aries-askar-shared/src/store/Scan.ts
@@ -57,31 +57,33 @@ export class Scan {
       })
     }
 
-    // Allow max of 256 per fetch operation
-    const chunk = this.limit ? Math.min(256, this.limit) : 256
-    let recordCount = 0
-    // Loop while limit not reached (or no limit specified)
-    while (!this.limit || recordCount < this.limit) {
+    try {
+      // Allow max of 256 per fetch operation
+      const chunk = this.limit ? Math.min(256, this.limit) : 256
+      let recordCount = 0
+      // Loop while limit not reached (or no limit specified)
+      while (!this.limit || recordCount < this.limit) {
+        // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+        this._listHandle = await ariesAskar.scanNext({ scanHandle: this._handle! })
+
+        const list = new EntryList({ handle: this._listHandle })
+
+        recordCount = recordCount + list.length
+        for (let index = 0; index < list.length; index++) {
+          const entry = list.getEntryByIndex(index)
+          cb(entry)
+        }
+
+        // If the number of records returned is less than chunk
+        // It means we reached the end of the iterator (no more records)
+        if (list.length < chunk) {
+          break
+        }
+      }
+    } finally {
       // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-      this._listHandle = await ariesAskar.scanNext({ scanHandle: this._handle! })
-
-      const list = new EntryList({ handle: this._listHandle })
-
-      recordCount = recordCount + list.length
-      for (let index = 0; index < list.length; index++) {
-        const entry = list.getEntryByIndex(index)
-        cb(entry)
-      }
-
-      // If the number of records returned is less than chunk
-      // It means we reached the end of the iterator (no more records)
-      if (list.length < chunk) {
-        break
-      }
+      ariesAskar.scanFree({ scanHandle: this._handle! })
     }
-
-    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-    ariesAskar.scanFree({ scanHandle: this._handle! })
   }
 
   public async fetchAll() {


### PR DESCRIPTION
When using `Scan.fetchAll` I found that the scan handle was not always properly freed. It turns out that this had to do with an error thrown when calling `scanNext` due to no records have been found (related issue https://github.com/hyperledger/aries-askar/issues/77), which prevented the code from executing the scanFree call.

So here we simply add a try-finally to make sure it is always being called.