### PR TITLE
fix(js): key handle name

### DIFF
--- a/wrappers/javascript/aries-askar-nodejs/src/NodeJSAriesAskar.ts
+++ b/wrappers/javascript/aries-askar-nodejs/src/NodeJSAriesAskar.ts
@@ -506,9 +506,9 @@ export class NodeJSAriesAskar implements AriesAskar {
   }
 
   public keyFree(options: KeyFreeOptions): void {
-    const { keyHandle } = serializeArguments(options)
+    const { localKeyHandle } = serializeArguments(options)
 
-    nativeAriesAskar.askar_key_free(keyHandle)
+    nativeAriesAskar.askar_key_free(localKeyHandle)
     handleError()
   }
 

--- a/wrappers/javascript/aries-askar-shared/src/ariesAskar/AriesAskar.ts
+++ b/wrappers/javascript/aries-askar-shared/src/ariesAskar/AriesAskar.ts
@@ -96,7 +96,7 @@ export type KeyEntryListGetMetadataOptions = { keyEntryListHandle: KeyEntryListH
 export type KeyEntryListGetNameOptions = { keyEntryListHandle: KeyEntryListHandle; index: number }
 export type KeyEntryListGetTagsOptions = { keyEntryListHandle: KeyEntryListHandle; index: number }
 export type KeyEntryListLoadLocalOptions = { keyEntryListHandle: KeyEntryListHandle; index: number }
-export type KeyFreeOptions = { keyHandle: LocalKeyHandle }
+export type KeyFreeOptions = { localKeyHandle: LocalKeyHandle }
 export type KeyFromJwkOptions = { jwk: Jwk }
 export type KeyFromKeyExchangeOptions = {
   algorithm: KeyAlgs

--- a/wrappers/javascript/aries-askar-shared/src/crypto/handles.ts
+++ b/wrappers/javascript/aries-askar-shared/src/crypto/handles.ts
@@ -126,7 +126,7 @@ export class KeyEntryListHandle extends ArcHandle {
 
 export class LocalKeyHandle extends ArcHandle {
   public free() {
-    ariesAskar.keyFree({ keyHandle: this })
+    ariesAskar.keyFree({ localKeyHandle: this })
   }
 
   public static fromHandle(handle: ArcHandleType) {


### PR DESCRIPTION
There was a small inconsistency between the key handle name for `keyFree` between node.js and react native. As all other methods use `localKeyHandle` (which the RN also expected), i've changed the method and node implementation.