### PR TITLE
fix(js): scan fetch record limit

### DIFF
--- a/wrappers/javascript/aries-askar-shared/src/store/Scan.ts
+++ b/wrappers/javascript/aries-askar-shared/src/store/Scan.ts
@@ -58,8 +58,6 @@ export class Scan {
     }
 
     try {
-      // Allow max of 256 per fetch operation
-      const chunk = this.limit ? Math.min(256, this.limit) : 256
       let recordCount = 0
       // Loop while limit not reached (or no limit specified)
       while (!this.limit || recordCount < this.limit) {
@@ -74,12 +72,6 @@ export class Scan {
         for (let index = 0; index < list.length; index++) {
           const entry = list.getEntryByIndex(index)
           cb(entry)
-        }
-
-        // If the number of records returned is less than chunk
-        // It means we reached the end of the iterator (no more records)
-        if (list.length < chunk) {
-          break
         }
       }
     } finally {


### PR DESCRIPTION
There is an unnecessary chunk variable (inherited from previous Indy SDK implementation in AFJ) that is preventing `fetchAll` to retrieve all records when they are more than PAGE_SIZE. As a result, a given Scan cannot return more than 32 entries.

Simply checking for `listHandle` (`scanNext` return value) validity seems to be enough to determine if there are no more matching records.
