### PR TITLE
chore: lower iOS compatibility

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,7 +1,7 @@
 name: "Aries-Askar"
 
 env:
-  RUST_VERSION: "1.60.0"
+  RUST_VERSION: "1.61.0"
   CROSS_VERSION: "0.2.4"
 
 on:
@@ -371,6 +371,7 @@ jobs:
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@master
         with:
+          toolchain: ${{ env.RUST_VERSION }}
           targets: ${{ matrix.target }}
 
       - name: Build

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -371,16 +371,7 @@ jobs:
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@master
         with:
-          # First version with support for cdylib: https://github.com/rust-lang/rust/pull/100636
-          toolchain: "1.65.0"
           targets: ${{ matrix.target }}
-
-      # Not useful unless the toolchain version matches the default
-      # - name: Cache cargo resources
-      #   uses: Swatinem/rust-cache@v2
-      #   with:
-      #     shared-key: deps
-      #     save-if: false
 
       - name: Build
         run: |
@@ -390,7 +381,7 @@ jobs:
         uses: actions/upload-artifact@v3
         with:
           name: library-${{ matrix.target }}
-          path: target/${{ matrix.target }}/release/libaries_askar.dylib
+          path: target/${{ matrix.target }}/release/libaries_askar.a
 
   build-android:
     name: Build library (Android)
@@ -436,7 +427,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
 
-      - name: Fetch dynamic libraries
+      - name: Fetch static libraries
         uses: actions/download-artifact@v3
 
       - run: >

--- a/build-xcframework.sh
+++ b/build-xcframework.sh
@@ -10,14 +10,16 @@ then
 fi
 
 NAME="aries_askar"
+BUNDLE_NAME="aries-askar"
 VERSION=$(cargo generate-lockfile && cargo pkgid | sed -e "s/^.*#//")
-BUNDLE_IDENTIFIER="org.hyperledger.$NAME"
-LIBRARY_NAME="lib$NAME.dylib"
+BUNDLE_IDENTIFIER="org.hyperledger.$BUNDLE_NAME"
+LIBRARY_NAME="lib$NAME.a"
 XC_FRAMEWORK_NAME="$NAME.xcframework"
 FRAMEWORK_LIBRARY_NAME=$NAME
 FRAMEWORK_NAME="$FRAMEWORK_LIBRARY_NAME.framework"
 HEADER_NAME="lib$NAME.h"
 OUT_PATH="out"
+MIN_IOS_VERSION="12.0"
 
 # Setting some default paths
 AARCH64_APPLE_IOS_PATH="./target/aarch64-apple-ios/release"
@@ -156,6 +158,8 @@ cat <<EOT >> Info.plist
 	<string>$VERSION</string>
 	<key>NSPrincipalClass</key>
 	<string></string>
+  <key>MinimumOSVersion</key>
+  <string>$MIN_IOS_VERSION</string>
 </dict>
 </plist>
 EOT
@@ -178,9 +182,5 @@ xcodebuild -create-xcframework \
 
 echo "cleaning up..."
 rm -rf $FRAMEWORK_NAME real sim
-
-echo "Fixing the identifiers of the library..."
-install_name_tool -id  @rpath/$NAME.framework/$FRAMEWORK_LIBRARY_NAME $XC_FRAMEWORK_NAME/ios-arm64/$FRAMEWORK_NAME/$FRAMEWORK_LIBRARY_NAME
-install_name_tool -id  @rpath/$NAME.framework/$FRAMEWORK_LIBRARY_NAME $XC_FRAMEWORK_NAME/ios-arm64_x86_64-simulator/$FRAMEWORK_NAME/$FRAMEWORK_LIBRARY_NAME
 
 echo "Framework written to $OUT_PATH/$XC_FRAMEWORK_NAME"


### PR DESCRIPTION
- Use static libraries for iOS for lower version compatibility
- Use rust 1.61.0 in CI as hashbrown needs 1.61.0 minimum.