### PR TITLE
chore: update version for js wrapper

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -22,8 +22,13 @@ on:
         required: true
         default: false
         type: boolean
-      publish-wrappers:
-        description: "Publish Wrappers to Registries"
+      publish-python-wrapper:
+        description: "Publish Python Wrapper to Registries"
+        required: true
+        default: false
+        type: boolean
+      publish-javascript-wrapper:
+        description: "Publish JavaScript Wrapper to Registries"
         required: true
         default: false
         type: boolean
@@ -286,7 +291,7 @@ jobs:
 
       - if: |
           github.event_name == 'release' ||
-          (github.event_name == 'workflow_dispatch' && github.event.inputs.publish-wrappers == 'true')
+          (github.event_name == 'workflow_dispatch' && github.event.inputs.publish-python-wrapper == 'true')
         name: Publish
         env:
           TWINE_USERNAME: ${{ secrets.PYPI_USERNAME }}
@@ -341,7 +346,7 @@ jobs:
       - name: Set NPM config
         if: |
           github.event_name == 'release' ||
-          (github.event_name == 'workflow_dispatch' && github.event.inputs.publish-wrappers == 'true')
+          (github.event_name == 'workflow_dispatch' && github.event.inputs.publish-javascript-wrapper == 'true')
         run: |
           echo "//registry.npmjs.org/:_authToken=${{ secrets.NPM_TOKEN }}" >> .npmrc
           echo "registry=https://registry.npmjs.org/" >> .npmrc
@@ -354,7 +359,7 @@ jobs:
       - name: Publish
         if: |
           github.event_name == 'release' ||
-          (github.event_name == 'workflow_dispatch' && github.event.inputs.publish-wrappers == 'true')
+          (github.event_name == 'workflow_dispatch' && github.event.inputs.publish-javascript-wrapper == 'true')
         run: npx lerna publish from-package --no-push --no-private --yes --no-git-tag-version
 
   build-ios:

--- a/wrappers/javascript/aries-askar-nodejs/README.md
+++ b/wrappers/javascript/aries-askar-nodejs/README.md
@@ -25,3 +25,11 @@ const key = Key.fromSeed({ algorithm: KeyAlgs.Bls12381G1, seed })
 ```
 
 > **Note**: If you want to use this library in a cross-platform environment you need to import methods from the `@hyperledger/aries-askar-shared` package instead. This is a platform independent package that allows to register the native bindings. The `@hyperledger/aries-askar-nodejs` package uses this package under the hood. See the [Aries Askar Shared README](https://github.com/hyperledger/aries-askar/tree/main/wrappers/javascript/aries-askar-shared/README.md) for documentation on how to use this package.
+
+## Version Compatibility
+
+The JavaScript wrapper is versioned independently from the native bindings. The following table shows the compatibility between the different versions:
+
+| Aries Askar | JavaScript Wrapper |
+| ----------- | ------------------ |
+| v0.2.9      | v0.1.0, v0.1.1     |

--- a/wrappers/javascript/aries-askar-nodejs/package.json
+++ b/wrappers/javascript/aries-askar-nodejs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperledger/aries-askar-nodejs",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "license": "Apache-2.0",
   "description": "Nodejs wrapper for Aries Askar",
   "source": "src/index",
@@ -47,7 +47,7 @@
     "typescript": "4.5.5"
   },
   "dependencies": {
-    "@hyperledger/aries-askar-shared": "0.1.0",
+    "@hyperledger/aries-askar-shared": "0.1.1",
     "@mapbox/node-pre-gyp": "^1.0.10",
     "ffi-napi": "^4.0.3",
     "node-cache": "^5.1.2",

--- a/wrappers/javascript/aries-askar-react-native/README.md
+++ b/wrappers/javascript/aries-askar-react-native/README.md
@@ -26,3 +26,11 @@ const key = Key.fromSeed({ algorithm: KeyAlgs.Bls12381G1, seed })
 ```
 
 > **Note**: If you want to use this library in a cross-platform environment you need to import methods from the `@hyperledger/aries-askar-shared` package instead. This is a platform independent package that allows to register the native bindings. The `@hyperledger/aries-askar-react-native` package uses this package under the hood. See the [Aries Askar Shared README](https://github.com/hyperledger/aries-askar/tree/main/wrappers/javascript/aries-askar-shared/README.md) for documentation on how to use this package.
+
+## Version Compatibility
+
+The JavaScript wrapper is versioned independently from the native bindings. The following table shows the compatibility between the different versions:
+
+| Aries Askar | JavaScript Wrapper |
+| ----------- | ------------------ |
+| v0.2.9      | v0.1.0, v0.1.1     |

--- a/wrappers/javascript/aries-askar-react-native/package.json
+++ b/wrappers/javascript/aries-askar-react-native/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperledger/aries-askar-react-native",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "license": "Apache-2.0",
   "description": "React Native wrapper for Aries Askar",
   "main": "build/index",
@@ -35,7 +35,7 @@
     "install": "node-pre-gyp install"
   },
   "dependencies": {
-    "@hyperledger/aries-askar-shared": "0.1.0",
+    "@hyperledger/aries-askar-shared": "0.1.1",
     "@mapbox/node-pre-gyp": "^1.0.10"
   },
   "devDependencies": {

--- a/wrappers/javascript/aries-askar-shared/README.md
+++ b/wrappers/javascript/aries-askar-shared/README.md
@@ -34,4 +34,10 @@ try {
 
 How you approach it is up to you, as long as the native binding are called before any actions are performed on the Aries Askar library.
 
----
+## Version Compatibility
+
+The JavaScript wrapper is versioned independently from the native bindings. The following table shows the compatibility between the different versions:
+
+| Aries Askar | JavaScript Wrapper |
+| ----------- | ------------------ |
+| v0.2.9      | v0.1.0, v0.1.1     |

--- a/wrappers/javascript/aries-askar-shared/package.json
+++ b/wrappers/javascript/aries-askar-shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperledger/aries-askar-shared",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "license": "Apache-2.0",
   "description": "Shared library for using Aries Askar with NodeJS and React Native",
   "main": "build/index",

--- a/wrappers/javascript/lerna.json
+++ b/wrappers/javascript/lerna.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.1.0",
+  "version": "0.1.1",
   "useWorkspaces": true,
   "npmClient": "yarn",
   "command": {


### PR DESCRIPTION
Updates version for the JS wrapper to 0.1.1 so we can make another release before updating the JS wrapper with the changes for the 0.3 release.

Also adds new options publish-javascript-wrapper and publish-python-wrapper instead of publish-wrappers in the CI, so we can release the JS wrapper separately.

Also adds a version compatibility between Aries Askar version and the JS wrapper version.