### PR TITLE
fix(js): add p384 key algo

### DIFF
--- a/wrappers/javascript/aries-askar-shared/src/enums/KeyAlgs.ts
+++ b/wrappers/javascript/aries-askar-shared/src/enums/KeyAlgs.ts
@@ -16,6 +16,7 @@ export enum KeyAlgs {
   X25519 = 'x25519',
   EcSecp256k1 = 'k256',
   EcSecp256r1 = 'p256',
+  EcSecp384r1 = 'p384',
 }
 
 export const keyAlgFromString = (alg: string): KeyAlgs => {


### PR DESCRIPTION
This simply adds a constant for P384 key algo support (added in #157) from JS. 