### PR TITLE
Add method to ping store sessions; verify profile existence when opening a session

### DIFF
--- a/askar-storage/src/any.rs
+++ b/askar-storage/src/any.rs
@@ -239,6 +239,11 @@ impl BackendSession for AnyBackendSession {
             .update(kind, operation, category, name, value, tags, expiry_ms)
     }
 
+    /// Test the connection to the store
+    fn ping(&mut self) -> BoxFuture<'_, Result<(), Error>> {
+        self.0.ping()
+    }
+
     /// Close the current store session
     fn close(&mut self, commit: bool) -> BoxFuture<'_, Result<(), Error>> {
         self.0.close(commit)

--- a/askar-storage/src/backend/mod.rs
+++ b/askar-storage/src/backend/mod.rs
@@ -209,7 +209,7 @@ pub async fn copy_store<'m, B: Backend, M: ManageBackend<'m>>(
     key_method: StoreKeyMethod,
     pass_key: PassKey<'m>,
     recreate: bool,
-) -> Result<(), Error> {
+) -> Result<<M as ManageBackend<'m>>::Backend, Error> {
     let default_profile = source.get_default_profile().await?;
     let profile_ids = source.list_profiles().await?;
     let target = target
@@ -218,5 +218,5 @@ pub async fn copy_store<'m, B: Backend, M: ManageBackend<'m>>(
     for profile in profile_ids {
         copy_profile(source, &target, &profile, &profile).await?;
     }
-    Ok(())
+    Ok(target)
 }

--- a/askar-storage/src/backend/mod.rs
+++ b/askar-storage/src/backend/mod.rs
@@ -170,6 +170,9 @@ pub trait BackendSession: Debug + Send {
         expiry_ms: Option<i64>,
     ) -> BoxFuture<'q, Result<(), Error>>;
 
+    /// Test the connection to the store
+    fn ping(&mut self) -> BoxFuture<'_, Result<(), Error>>;
+
     /// Close the current store session
     fn close(&mut self, commit: bool) -> BoxFuture<'_, Result<(), Error>>;
 }

--- a/askar-storage/src/backend/postgres/mod.rs
+++ b/askar-storage/src/backend/postgres/mod.rs
@@ -156,7 +156,8 @@ impl Backend for PostgresBackend {
             let profile: Option<String> = sqlx::query_scalar(CONFIG_FETCH_QUERY)
                 .bind("default_profile")
                 .fetch_one(conn.as_mut())
-                .await?;
+                .await
+                .map_err(err_map!(Backend, "Error fetching default profile name"))?;
             Ok(profile.unwrap_or_default())
         })
     }
@@ -168,7 +169,8 @@ impl Backend for PostgresBackend {
                 .bind("default_profile")
                 .bind(profile)
                 .execute(conn.as_mut())
-                .await?;
+                .await
+                .map_err(err_map!(Backend, "Error setting default profile name"))?;
             Ok(())
         })
     }
@@ -178,7 +180,8 @@ impl Backend for PostgresBackend {
             let mut conn = self.conn_pool.acquire().await?;
             let rows = sqlx::query("SELECT name FROM profiles")
                 .fetch_all(conn.as_mut())
-                .await?;
+                .await
+                .map_err(err_map!(Backend, "Error fetching profile list"))?;
             let names = rows.into_iter().flat_map(|r| r.try_get(0)).collect();
             Ok(names)
         })
@@ -190,7 +193,8 @@ impl Backend for PostgresBackend {
             Ok(sqlx::query("DELETE FROM profiles WHERE name=$1")
                 .bind(&name)
                 .execute(conn.as_mut())
-                .await?
+                .await
+                .map_err(err_map!(Backend, "Error removing profile"))?
                 .rows_affected()
                 != 0)
         })
@@ -340,7 +344,8 @@ impl BackendSession for DbSession<Postgres> {
             let mut active = acquire_session(&mut *self).await?;
             let count = sqlx::query_scalar_with(query.as_str(), params)
                 .fetch_one(active.connection_mut())
-                .await?;
+                .await
+                .map_err(err_map!(Backend, "Error performing count query"))?;
             Ok(count)
         })
     }
@@ -380,7 +385,8 @@ impl BackendSession for DbSession<Postgres> {
             .bind(enc_category)
             .bind(enc_name)
             .fetch_optional(active.connection_mut())
-            .await?
+            .await
+            .map_err(err_map!(Backend, "Error performing fetch query"))?
             {
                 let value = row.try_get(1)?;
                 let tags = row.try_get::<Option<String>, _>(2)?.map(String::into_bytes);
@@ -550,7 +556,9 @@ impl BackendSession for DbSession<Postgres> {
             let mut sess = acquire_session(&mut *self).await?;
             if sess.in_transaction() {
                 // the profile row is locked, perform a typical ping
-                sqlx::Connection::ping(sess.connection_mut()).await?;
+                sqlx::Connection::ping(sess.connection_mut())
+                    .await
+                    .map_err(err_map!(Backend, "Error pinging session"))?;
             } else {
                 let count: i64 = sqlx::query_scalar("SELECT COUNT(*) FROM profiles WHERE id=$1")
                     .bind(sess.profile_id)
@@ -668,7 +676,7 @@ async fn perform_insert(
             .bind(expiry_ms.map(expiry_timestamp).transpose()?)
             .fetch_optional(active.connection_mut())
             .await?
-            .ok_or_else(|| err_msg!(Duplicate, "Duplicate row"))?
+            .ok_or_else(|| err_msg!(Duplicate, "Duplicate entry"))?
     } else {
         trace!("Update entry");
         let row_id: i64 = sqlx::query_scalar(UPDATE_QUERY)
@@ -680,11 +688,12 @@ async fn perform_insert(
             .bind(expiry_ms.map(expiry_timestamp).transpose()?)
             .fetch_one(active.connection_mut())
             .await
-            .map_err(|_| err_msg!(NotFound, "Error updating existing row"))?;
+            .map_err(|_| err_msg!(NotFound, "Error updating existing entry"))?;
         sqlx::query(TAG_DELETE_QUERY)
             .bind(row_id)
             .execute(active.connection_mut())
-            .await?;
+            .await
+            .map_err(err_map!(Backend, "Error removing existing entry tags"))?;
         row_id
     };
     if let Some(tags) = enc_tags {
@@ -695,7 +704,8 @@ async fn perform_insert(
                 .bind(&tag.value)
                 .bind(tag.plaintext as i16)
                 .execute(active.connection_mut())
-                .await?;
+                .await
+                .map_err(err_map!(Backend, "Error inserting entry tags"))?;
         }
     }
     Ok(())
@@ -715,7 +725,8 @@ async fn perform_remove<'q>(
         .bind(enc_category)
         .bind(enc_name)
         .execute(active.connection_mut())
-        .await?;
+        .await
+        .map_err(err_map!(Backend, "Error removing entry"))?;
     if done.rows_affected() == 0 && !ignore_error {
         Err(err_msg!(NotFound, "Entry not found"))
     } else {

--- a/askar-storage/tests/backends.rs
+++ b/askar-storage/tests/backends.rs
@@ -243,7 +243,7 @@ mod sqlite {
                 .await
                 .expect("Error fetching default profile");
 
-            copy_store(
+            let target = copy_store(
                 &source,
                 url_target.as_str(),
                 StoreKeyMethod::RawKey,
@@ -252,6 +252,7 @@ mod sqlite {
             )
             .await
             .expect("Error copying store");
+            target.close().await.expect("Error closing copied store");
 
             source.close().await.expect("Error closing store");
             SqliteStoreOptions::new(fname_source.as_str())

--- a/askar-storage/tests/utils/mod.rs
+++ b/askar-storage/tests/utils/mod.rs
@@ -34,6 +34,7 @@ pub async fn db_create_remove_profile(db: AnyBackend) {
     sess.ping()
         .await
         .expect_err("Expected connection to removed session to fail");
+    sess.close(false).await.unwrap();
     assert!(!db
         .remove_profile("not a profile".to_string())
         .await

--- a/askar-storage/tests/utils/mod.rs
+++ b/askar-storage/tests/utils/mod.rs
@@ -23,14 +23,21 @@ const ERR_SCAN_NEXT: &str = "Error fetching scan rows";
 
 pub async fn db_create_remove_profile(db: AnyBackend) {
     let profile = db.create_profile(None).await.expect(ERR_PROFILE);
+    let mut sess = db.session(Some(profile.clone()), false).expect(ERR_PROFILE);
+    sess.ping().await.expect(ERR_PROFILE);
+    sess.close(false).await.unwrap();
     assert!(db
-        .remove_profile(profile)
+        .remove_profile(profile.clone())
         .await
-        .expect("Error removing profile"),);
+        .expect("Error removing profile"));
+    let mut sess = db.session(Some(profile.clone()), false).expect(ERR_PROFILE);
+    sess.ping()
+        .await
+        .expect_err("Expected connection to removed session to fail");
     assert!(!db
         .remove_profile("not a profile".to_string())
         .await
-        .expect("Error removing profile"),);
+        .expect("Error removing profile"));
 }
 
 pub async fn db_fetch_fail(db: AnyBackend) {

--- a/src/store.rs
+++ b/src/store.rs
@@ -143,15 +143,23 @@ impl Store {
     /// Create a new session against the store
     pub async fn session(&self, profile: Option<String>) -> Result<Session, Error> {
         let mut sess = Session::new(self.0.session(profile, false)?);
-        sess.ping().await?;
-        Ok(sess)
+        if let Err(e) = sess.ping().await {
+            sess.0.close(false).await?;
+            Err(e)
+        } else {
+            Ok(sess)
+        }
     }
 
     /// Create a new transaction session against the store
     pub async fn transaction(&self, profile: Option<String>) -> Result<Session, Error> {
         let mut txn = Session::new(self.0.session(profile, true)?);
-        txn.ping().await?;
-        Ok(txn)
+        if let Err(e) = txn.ping().await {
+            txn.0.close(false).await?;
+            Err(e)
+        } else {
+            Ok(txn)
+        }
     }
 
     /// Close the store instance, waiting for any shutdown procedures to complete.

--- a/src/store.rs
+++ b/src/store.rs
@@ -142,12 +142,16 @@ impl Store {
 
     /// Create a new session against the store
     pub async fn session(&self, profile: Option<String>) -> Result<Session, Error> {
-        Ok(Session::new(self.0.session(profile, false)?))
+        let mut sess = Session::new(self.0.session(profile, false)?);
+        sess.ping().await?;
+        Ok(sess)
     }
 
     /// Create a new transaction session against the store
     pub async fn transaction(&self, profile: Option<String>) -> Result<Session, Error> {
-        Ok(Session::new(self.0.session(profile, true)?))
+        let mut txn = Session::new(self.0.session(profile, true)?);
+        txn.ping().await?;
+        Ok(txn)
     }
 
     /// Close the store instance, waiting for any shutdown procedures to complete.
@@ -502,6 +506,11 @@ impl Session {
             .await?;
 
         Ok(())
+    }
+
+    /// Test the connection to the store
+    pub async fn ping(&mut self) -> Result<(), Error> {
+        Ok(self.0.ping().await?)
     }
 
     /// Commit the pending transaction

--- a/src/store.rs
+++ b/src/store.rs
@@ -95,7 +95,6 @@ impl Store {
             .provision_backend(key_method, pass_key, Some(default_profile), recreate)
             .await?;
         for profile in profile_ids {
-            println!("copy profile: {}", profile);
             copy_profile(&self.0, &target, &profile, &profile).await?;
         }
         Ok(Self::new(target))

--- a/wrappers/javascript/aries-askar-nodejs/tests/store.test.ts
+++ b/wrappers/javascript/aries-askar-nodejs/tests/store.test.ts
@@ -265,10 +265,8 @@ describe('Store and Session', () => {
 
     await store.removeProfile(profile)
 
-    // Profile key is cached
-    const session5 = await store.session(profile).open()
-    await expect(session5.count(firstEntry)).resolves.toStrictEqual(0)
-    await session5.close()
+    // Opening removed profile should fail
+    await expect(store.session(profile).open()).rejects.toThrowError(AriesAskarError)
 
     // Unknown profile
     const session6 = await store.session('unknown profile').open()

--- a/wrappers/javascript/aries-askar-nodejs/tests/store.test.ts
+++ b/wrappers/javascript/aries-askar-nodejs/tests/store.test.ts
@@ -268,10 +268,10 @@ describe('Store and Session', () => {
     // Opening removed profile should fail
     await expect(store.session(profile).open()).rejects.toThrowError(AriesAskarError)
 
-    // Unknown profile
-    const session6 = await store.session('unknown profile').open()
-    await expect(session6.count(firstEntry)).rejects.toThrowError(AriesAskarError)
-    await session6.close()
+    // Unknown unknown profile should fail
+    await expect(store.session('unknown profile').open()).rejects.toThrowError(AriesAskarError)
+
+    await expect(store.createProfile(profile)).resolves.toStrictEqual(profile)
 
     const session7 = await store.session(profile).open()
     await expect(session7.count(firstEntry)).resolves.toStrictEqual(0)

--- a/wrappers/python/tests/test_store.py
+++ b/wrappers/python/tests/test_store.py
@@ -346,13 +346,12 @@ async def test_profile(store: Store):
 
     assert set(await store.list_profiles()) == {active_profile}
 
-    # profile key is cached
-    async with store.session(profile) as session:
-        assert (
+    # opening removed profile should fail
+    with raises(AskarError, match="removed"):
+        async with store.session(profile) as session:
             await session.count(
                 TEST_ENTRY["category"], {"~plaintag": "a", "enctag": "b"}
             )
-        ) == 0
 
     with raises(AskarError, match="not found"):
         async with store.session("unknown profile") as session:

--- a/wrappers/python/tests/test_store.py
+++ b/wrappers/python/tests/test_store.py
@@ -349,15 +349,12 @@ async def test_profile(store: Store):
     # opening removed profile should fail
     with raises(AskarError, match="removed"):
         async with store.session(profile) as session:
-            await session.count(
-                TEST_ENTRY["category"], {"~plaintag": "a", "enctag": "b"}
-            )
+            pass
 
+    # opening unknown profile should fail
     with raises(AskarError, match="not found"):
         async with store.session("unknown profile") as session:
-            await session.count(
-                TEST_ENTRY["category"], {"~plaintag": "a", "enctag": "b"}
-            )
+            pass
 
     await store.create_profile(profile)
 


### PR DESCRIPTION
Fixes #163 

For Postgres, this also ensures that a profile cannot be removed while there is an active transaction against it.

Includes a fix for the persistent test failure copying a Store instance on Windows.