### PR TITLE
Actively return pool connections

### DIFF
--- a/askar-storage/tests/backends.rs
+++ b/askar-storage/tests/backends.rs
@@ -265,7 +265,7 @@ mod sqlite {
                 .expect("Error initializing sqlite store options")
                 .open_backend(Some(StoreKeyMethod::RawKey), key_target.as_ref(), None)
                 .await
-                .expect("Error opening rekeyed store");
+                .expect("Error opening copied store");
             assert_eq!(copied.get_active_profile(), profile);
             copied.close().await.expect("Error closing store");
 


### PR DESCRIPTION
Rather than relying on a closing task to be scheduled on the async runtime, we can actively return pool connections in most cases. It seems like this may help avoid the intermittent failure of the `copy_db` test on Windows due to a file lock.