### PR TITLE
Adjust lower maximum number of connections for sqlite

### DIFF
--- a/askar-storage/src/backend/sqlite/provision.rs
+++ b/askar-storage/src/backend/sqlite/provision.rs
@@ -24,7 +24,7 @@ use crate::{
 };
 
 const DEFAULT_MIN_CONNECTIONS: usize = 1;
-const DEFAULT_LOWER_MAX_CONNECTIONS: usize = 2;
+const DEFAULT_LOWER_MAX_CONNECTIONS: usize = 4;
 const DEFAULT_UPPER_MAX_CONNECTIONS: usize = 8;
 const DEFAULT_BUSY_TIMEOUT: Duration = Duration::from_secs(5);
 const DEFAULT_JOURNAL_MODE: SqliteJournalMode = SqliteJournalMode::Wal;


### PR DESCRIPTION
Based on testing against ACA-Py. I believe that the `available_parallelism` method comes up with a lower number than `num_cpus::count` did on Github CI, but in general a maximum of 2 connections does seem too low.