### PR TITLE
chore(js): update version to dev.3

### DIFF
--- a/wrappers/javascript/aries-askar-nodejs/package.json
+++ b/wrappers/javascript/aries-askar-nodejs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperledger/aries-askar-nodejs",
-  "version": "0.2.0-dev.2",
+  "version": "0.2.0-dev.3",
   "license": "Apache-2.0",
   "description": "Nodejs wrapper for Aries Askar",
   "source": "src/index",
@@ -48,7 +48,7 @@
   "dependencies": {
     "@2060.io/ffi-napi": "4.0.8",
     "@2060.io/ref-napi": "3.0.6",
-    "@hyperledger/aries-askar-shared": "0.2.0-dev.2",
+    "@hyperledger/aries-askar-shared": "0.2.0-dev.3",
     "@mapbox/node-pre-gyp": "^1.0.10",
     "node-cache": "^5.1.2",
     "ref-array-di": "^1.2.2",
@@ -57,7 +57,7 @@
   "binary": {
     "module_name": "aries_askar",
     "module_path": "native",
-    "remote_path": "v0.3.0-dev.1",
+    "remote_path": "v0.3.0",
     "host": "https://github.com/hyperledger/aries-askar/releases/download/",
     "package_name": "library-{platform}-{arch}.tar.gz"
   },

--- a/wrappers/javascript/aries-askar-react-native/package.json
+++ b/wrappers/javascript/aries-askar-react-native/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperledger/aries-askar-react-native",
-  "version": "0.2.0-dev.2",
+  "version": "0.2.0-dev.3",
   "license": "Apache-2.0",
   "description": "React Native wrapper for Aries Askar",
   "main": "build/index",
@@ -35,7 +35,7 @@
     "install": "node-pre-gyp install"
   },
   "dependencies": {
-    "@hyperledger/aries-askar-shared": "0.2.0-dev.2",
+    "@hyperledger/aries-askar-shared": "0.2.0-dev.3",
     "@mapbox/node-pre-gyp": "^1.0.10"
   },
   "devDependencies": {
@@ -54,7 +54,7 @@
   "binary": {
     "module_name": "aries_askar",
     "module_path": "native",
-    "remote_path": "v0.3.0-dev.1",
+    "remote_path": "v0.3.0",
     "host": "https://github.com/hyperledger/aries-askar/releases/download/",
     "package_name": "library-ios-android.tar.gz"
   }

--- a/wrappers/javascript/aries-askar-shared/package.json
+++ b/wrappers/javascript/aries-askar-shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperledger/aries-askar-shared",
-  "version": "0.2.0-dev.2",
+  "version": "0.2.0-dev.3",
   "license": "Apache-2.0",
   "description": "Shared library for using Aries Askar with NodeJS and React Native",
   "main": "build/index",

--- a/wrappers/javascript/lerna.json
+++ b/wrappers/javascript/lerna.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.2.0-dev.2",
+  "version": "0.2.0-dev.3",
   "npmClient": "yarn",
   "command": {
     "version": {


### PR DESCRIPTION
Updates the version of the JS wrappers for Askar to a new dev version.

I was a bit confused by the versions as the Python and Cargo versions were already set to 0.3, but no release was made yet. 

@andrewwhitehead are we good to make a release in the main branch for the Python and Rust binaries? Then we can merge this PR and release it, as this depends on the 0.3 library being released now

