### PR TITLE
fix(js): promise handle error and rn updates

### DIFF
--- a/wrappers/javascript/aries-askar-nodejs/package.json
+++ b/wrappers/javascript/aries-askar-nodejs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperledger/aries-askar-nodejs",
-  "version": "0.2.0-dev.4",
+  "version": "0.2.0-dev.5",
   "license": "Apache-2.0",
   "description": "Nodejs wrapper for Aries Askar",
   "source": "src/index",
@@ -48,7 +48,7 @@
   "dependencies": {
     "@2060.io/ffi-napi": "4.0.8",
     "@2060.io/ref-napi": "3.0.6",
-    "@hyperledger/aries-askar-shared": "0.2.0-dev.4",
+    "@hyperledger/aries-askar-shared": "0.2.0-dev.5",
     "@mapbox/node-pre-gyp": "^1.0.10",
     "node-cache": "^5.1.2",
     "ref-array-di": "^1.2.2",

--- a/wrappers/javascript/aries-askar-nodejs/src/NodeJSAriesAskar.ts
+++ b/wrappers/javascript/aries-askar-nodejs/src/NodeJSAriesAskar.ts
@@ -199,16 +199,20 @@ export class NodeJSAriesAskar implements AriesAskar {
   /**
    * Fetch the error from the native library and throw it as a JS error
    *
+   * NOTE:
    * Checks whether the error code of the returned error matches the error code that was passed to the function.
-   * This tries to partially solve the issue described here:
-   * https://github.com/openwallet-foundation/agent-framework-javascript/pull/1629#issuecomment-1856052292
+   * If it doesn't, we throw an error with the original errorCode, and a custom message explaining we weren't able
+   * to retrieve the error message from the native library. This should however not break functionality as long as
+   * error codes are used rather than error messages for error handling.
    *
    */
   private getAriesAskarError(errorCode: number): AriesAskarError {
     const error = this.getCurrentError()
     if (error.code !== errorCode) {
-      throw AriesAskarError.customError({
-        message: `Error code mismatch. Function received: '${errorCode}', but after fetch it was '${error.code}'`,
+      return new AriesAskarError({
+        code: errorCode,
+        message:
+          'Error details have already been overwritten on the native side, unable to retrieve error message for the error',
       })
     }
 

--- a/wrappers/javascript/aries-askar-react-native/package.json
+++ b/wrappers/javascript/aries-askar-react-native/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperledger/aries-askar-react-native",
-  "version": "0.2.0-dev.4",
+  "version": "0.2.0-dev.5",
   "license": "Apache-2.0",
   "description": "React Native wrapper for Aries Askar",
   "main": "build/index",
@@ -35,7 +35,7 @@
     "install": "node-pre-gyp install"
   },
   "dependencies": {
-    "@hyperledger/aries-askar-shared": "0.2.0-dev.4",
+    "@hyperledger/aries-askar-shared": "0.2.0-dev.5",
     "@mapbox/node-pre-gyp": "^1.0.10"
   },
   "devDependencies": {

--- a/wrappers/javascript/aries-askar-react-native/src/ReactNativeAriesAskar.ts
+++ b/wrappers/javascript/aries-askar-react-native/src/ReactNativeAriesAskar.ts
@@ -100,18 +100,22 @@ export class ReactNativeAriesAskar implements AriesAskar {
   }
 
   /**
-   * Fetch the error from the native library and throw it as a JS error
+   * Fetch the error from the native library and return it as a JS error
    *
+   * NOTE:
    * Checks whether the error code of the returned error matches the error code that was passed to the function.
-   * This tries to partially solve the issue described here:
-   * https://github.com/openwallet-foundation/agent-framework-javascript/pull/1629#issuecomment-1856052292
+   * If it doesn't, we throw an error with the original errorCode, and a custom message explaining we weren't able
+   * to retrieve the error message from the native library. This should however not break functionality as long as
+   * error codes are used rather than error messages for error handling.
    *
    */
   private getAriesAskarError(errorCode: number): AriesAskarError {
     const error = this.getCurrentError()
     if (error.code !== errorCode) {
-      throw AriesAskarError.customError({
-        message: `Error code mismatch. Function received: '${errorCode}', but after fetch it was '${error.code}'`,
+      return new AriesAskarError({
+        code: errorCode,
+        message:
+          'Error details have already been overwritten on the native side, unable to retrieve error message for the error',
       })
     }
 

--- a/wrappers/javascript/aries-askar-shared/package.json
+++ b/wrappers/javascript/aries-askar-shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperledger/aries-askar-shared",
-  "version": "0.2.0-dev.4",
+  "version": "0.2.0-dev.5",
   "license": "Apache-2.0",
   "description": "Shared library for using Aries Askar with NodeJS and React Native",
   "main": "build/index",

--- a/wrappers/javascript/lerna.json
+++ b/wrappers/javascript/lerna.json
@@ -1,4 +1,4 @@
 {
-  "version": "0.2.0-dev.4",
+  "version": "0.2.0-dev.5",
   "npmClient": "yarn"
 }


### PR DESCRIPTION
Some additional updates after #209.

It addresses two things:
- also handle error code mismatch in the promise callback
- update the RN implementation to handle the errors in the same way as we updated to in the node js wrapper. @berendsliedrecht you mentioned it was already implemented correctly in RN, were you talking about the unnessary error calling? Because the code matching logic was not present in the RN wrapper.

I've changed the mismatch behaviour handling to now throw an error with the original errorCode, and a custom message "Error has already been overwritten, unable to provide error message". That way it won't break the calling implementation, as long as they use errorCodes to  handle errors. I've looked and it seems we're not using error message from Askar anymore to do error handling, so this should fix the problem, except for not always having the correct error message in the logs.

