### PR TITLE
Add python requirements file and update dependabot workflow

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -25,6 +25,18 @@ updates:
       - dependency-name: "*"
         update-types: ["version-update:semver-major", "version-update:semver-patch"]
 
+  # Maintain dependencies for pip
+  - package-ecosystem: "pip"
+    directory: "/wrappers/python"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "04:00"
+      timezone: "Canada/Pacific"
+    ignore:
+      - dependency-name: "*"
+        update-types: ["version-update:semver-major", "version-update:semver-patch"]
+
   # Maintain dependencies for Cargo Packages
   - package-ecosystem: "cargo"
     directory: "/"

--- a/wrappers/python/requirements.dev.txt
+++ b/wrappers/python/requirements.dev.txt
@@ -1,0 +1,2 @@
+pytest~=8.2.1
+pytest-asyncio~=0.23.7

--- a/wrappers/python/requirements.txt
+++ b/wrappers/python/requirements.txt
@@ -1,0 +1,1 @@
+cached_property~=1.5.2

--- a/wrappers/python/setup.py
+++ b/wrappers/python/setup.py
@@ -2,6 +2,7 @@
 
 import os
 import runpy
+
 from setuptools import find_packages, setup
 
 PACKAGE_NAME = "aries_askar"
@@ -10,6 +11,12 @@ VERSION = version_meta["__version__"]
 
 with open(os.path.abspath("./README.md"), "r") as fh:
     long_description = fh.read()
+
+
+def parse_requirements(filename: str):
+    """Load requirements from a pip requirements file."""
+    line_iter = (line.strip() for line in open(filename))
+    return [line for line in line_iter if line and not line.startswith("#")]
 
 
 if __name__ == "__main__":
@@ -22,7 +29,8 @@ if __name__ == "__main__":
         long_description_content_type="text/markdown",
         url="https://github.com/hyperledger/aries-askar",
         packages=find_packages(),
-        install_requires=["cached_property~=1.5"],
+        install_requires=parse_requirements("requirements.txt"),
+        tests_require=parse_requirements("requirements.dev.txt"),
         include_package_data=True,
         package_data={
             "": [


### PR DESCRIPTION
Currently setup.py just indicates one dependency: `cached_property`.

It makes sense if the dependencies were parsed from a requirements.txt file (less effort than migrating to pyproject.toml format). Allows for easier management if any extras need to be added, and also means we can add pip dependency management to the dependabot workflow (namely to catch if there's an update to `cached_property`.

A requirements.dev.txt file is also added to track dev / test dependencies. I would add indy as a test requirement, since it's used in `indy_test.py`, but I can't find out which `indy` packages it's referring to ... it doesn't work with `pip install indy` or `python3-indy`. So for now I've just specified `pytest` and `pytest-asyncio`