### PR TITLE
:construction: WIP: Replace default python `json` library with `orjson`

### DIFF
--- a/wrappers/python/aries_askar/bindings/__init__.py
+++ b/wrappers/python/aries_askar/bindings/__init__.py
@@ -1,7 +1,7 @@
 """Low-level interaction with the aries-askar library."""
 
 import asyncio
-import json
+import orjson
 import logging
 
 from ctypes import POINTER, byref, c_int8, c_int32, c_int64
@@ -605,7 +605,7 @@ def key_get_secret_bytes(handle: LocalKeyHandle) -> ByteBuffer:
 def key_from_jwk(jwk: Union[dict, str, bytes]) -> LocalKeyHandle:
     handle = LocalKeyHandle()
     if isinstance(jwk, dict):
-        jwk = json.dumps(jwk)
+        jwk = orjson.dumps(jwk)
     invoke(
         "askar_key_from_jwk",
         (FfiByteBuffer, POINTER(LocalKeyHandle)),

--- a/wrappers/python/aries_askar/bindings/handle.py
+++ b/wrappers/python/aries_askar/bindings/handle.py
@@ -1,6 +1,6 @@
 """Handles for allocated resources."""
 
-import json
+import orjson
 import logging
 
 from ctypes import (
@@ -167,7 +167,7 @@ class EntryListHandle(ArcHandle):
             byref(tags),
         )
         if tags:
-            tags = json.loads(tags.value)
+            tags = orjson.loads(tags.value)
             for t in tags:
                 if isinstance(tags[t], list):
                     tags[t] = set(tags[t])
@@ -227,7 +227,7 @@ class KeyEntryListHandle(ArcHandle):
             index,
             byref(tags),
         )
-        return json.loads(tags.value) if tags else None
+        return orjson.loads(tags.value) if tags else None
 
     def load_key(self, index: int) -> "LocalKeyHandle":
         """Load the key instance."""

--- a/wrappers/python/aries_askar/bindings/lib.py
+++ b/wrappers/python/aries_askar/bindings/lib.py
@@ -1,7 +1,7 @@
 """Library instance and allocated buffer handling."""
 
 import asyncio
-import json
+import orjson
 import itertools
 import logging
 import os
@@ -280,8 +280,8 @@ class LibLoad:
         )
         if not method(byref(err_json)):
             try:
-                msg = json.loads(err_json.value)
-            except json.JSONDecodeError:
+                msg = orjson.loads(err_json.value)
+            except orjson.JSONDecodeError:
                 LOGGER.warning("JSON decode error for askar_get_current_error")
                 msg = None
             if msg and "message" in msg and "code" in msg:
@@ -540,7 +540,7 @@ class FfiJson:
         if isinstance(value, FfiStr):
             return value
         if isinstance(value, dict):
-            value = json.dumps(value)
+            value = orjson.dumps(value).decode()
         return FfiStr(value)
 
 
@@ -550,12 +550,12 @@ class FfiTagsJson:
         if isinstance(tags, FfiStr):
             return tags
         if tags:
-            tags = json.dumps(
+            tags = orjson.dumps(
                 {
                     name: (list(value) if isinstance(value, set) else value)
                     for name, value in tags.items()
                 }
-            )
+            ).decode()
         else:
             tags = None
         return FfiStr(tags)

--- a/wrappers/python/aries_askar/store.py
+++ b/wrappers/python/aries_askar/store.py
@@ -1,6 +1,6 @@
 """Handling of Store instances."""
 
-import json
+import orjson
 
 from typing import Optional, Sequence, Union
 
@@ -52,7 +52,7 @@ class Entry:
     @property
     def value_json(self) -> dict:
         """Accessor for the entry value as JSON."""
-        return json.loads(self.value)
+        return orjson.loads(self.value)
 
     @cached_property
     def tags(self) -> dict:
@@ -580,7 +580,7 @@ class Session:
         if not self._handle:
             raise AskarError(AskarErrorCode.WRAPPER, "Cannot update closed session")
         if value is None and value_json is not None:
-            value = json.dumps(value_json)
+            value = orjson.dumps(value_json)
         await bindings.session_update(
             self._handle, EntryOperation.INSERT, category, name, value, tags, expiry_ms
         )
@@ -598,7 +598,7 @@ class Session:
         if not self._handle:
             raise AskarError(AskarErrorCode.WRAPPER, "Cannot update closed session")
         if value is None and value_json is not None:
-            value = json.dumps(value_json)
+            value = orjson.dumps(value_json)
         await bindings.session_update(
             self._handle, EntryOperation.REPLACE, category, name, value, tags, expiry_ms
         )

--- a/wrappers/python/indy_test.py
+++ b/wrappers/python/indy_test.py
@@ -1,6 +1,6 @@
 import asyncio
 import indy
-import json
+import orjson
 import time
 
 PERF_ROWS = 10000
@@ -33,8 +33,8 @@ async def perf_test():
             "admin_password": "pgpass",
         }
 
-    config = json.dumps(wallet_config)
-    creds = json.dumps(wallet_creds)
+    config = orjson.dumps(wallet_config).decode()
+    creds = orjson.dumps(wallet_creds).decode()
 
     try:
         await indy.wallet.delete_wallet(config, creds)
@@ -47,7 +47,7 @@ async def perf_test():
 
     insert_start = time.perf_counter()
     for idx in range(PERF_ROWS):
-        tags_json = json.dumps({"~plaintag": "a", "enctag": "b"})
+        tags_json = orjson.dumps({"~plaintag": "a", "enctag": "b"}).decode()
         await indy.non_secrets.add_wallet_record(
             handle, "category", f"name-{idx}", "value", tags_json
         )
@@ -56,19 +56,19 @@ async def perf_test():
 
     rc = 0
     tags = 0
-    options_json = json.dumps(
+    options_json = orjson.dumps(
         {
             "retrieveType": True,
             "retrieveValue": True,
             "retrieveTags": True,
         }
-    )
+    ).decode()
     fetch_start = time.perf_counter()
     for idx in range(PERF_ROWS):
         result_json = await indy.non_secrets.get_wallet_record(
             handle, "category", f"name-{idx}", options_json
         )
-        result = json.loads(result_json)
+        result = orjson.loads(result_json)
         rc += 1
         tags += len(result["tags"])
     dur = time.perf_counter() - fetch_start
@@ -76,7 +76,7 @@ async def perf_test():
 
     rc = 0
     tags = 0
-    options_json = json.dumps(
+    options_json = orjson.dumps(
         {
             "retrieveRecords": True,
             "retrieveTotalCount": False,
@@ -84,7 +84,7 @@ async def perf_test():
             "retrieveValue": True,
             "retrieveTags": True,
         }
-    )
+    ).decode()
     scan_start = time.perf_counter()
     search_handle = await indy.non_secrets.open_wallet_search(
         handle, "category", "{}", options_json
@@ -93,7 +93,7 @@ async def perf_test():
         result_json = await indy.non_secrets.fetch_wallet_search_next_records(
             handle, search_handle, 20
         )
-        results = json.loads(result_json)
+        results = orjson.loads(result_json)
         if results["records"]:
             for row in results["records"]:
                 rc += 1

--- a/wrappers/python/requirements.txt
+++ b/wrappers/python/requirements.txt
@@ -1,1 +1,2 @@
 cached_property~=1.5.2
+orjson~=3.10.3

--- a/wrappers/python/tests/test_keys.py
+++ b/wrappers/python/tests/test_keys.py
@@ -1,4 +1,4 @@
-import json
+import orjson
 
 from aries_askar.types import KeyBackend
 import pytest
@@ -79,11 +79,11 @@ def test_ed25519():
     kex = x25519_key.key_exchange(KeyAlg.XC20P, x25519_key_2)
     assert isinstance(kex, Key)
 
-    jwk = json.loads(key.get_jwk_public())
+    jwk = orjson.loads(key.get_jwk_public())
     assert jwk["kty"] == "OKP"
     assert jwk["crv"] == "Ed25519"
 
-    jwk = json.loads(key.get_jwk_secret())
+    jwk = orjson.loads(key.get_jwk_secret())
     assert jwk["kty"] == "OKP"
     assert jwk["crv"] == "Ed25519"
 
@@ -99,13 +99,13 @@ def test_ec_curves(key_alg: KeyAlg):
     sig = key.sign_message(message)
     assert key.verify_signature(message, sig)
 
-    jwk = json.loads(key.get_jwk_public())
+    jwk = orjson.loads(key.get_jwk_public())
     assert jwk["kty"] == "EC"
     assert jwk["crv"]
     assert jwk["x"]
     assert jwk["y"]
 
-    jwk = json.loads(key.get_jwk_secret())
+    jwk = orjson.loads(key.get_jwk_secret())
     assert jwk["kty"] == "EC"
     assert jwk["crv"]
     assert jwk["x"]


### PR DESCRIPTION
json operations are notoriously expensive, especially with the default python library. `orjson` boasts 10x fastert de/serialisation speeds. So it'd be great if the python wrapper offered `orjson` an optional alternative.