### PR TITLE
feat: expose argon2 over ffi

### DIFF
--- a/include/libaries_askar.h
+++ b/include/libaries_askar.h
@@ -48,25 +48,6 @@ typedef struct Option_EnabledCallback Option_EnabledCallback;
 
 typedef struct Option_FlushCallback Option_FlushCallback;
 
-typedef struct SecretBuffer {
-  int64_t len;
-  uint8_t *data;
-} SecretBuffer;
-
-typedef struct FfiResultList_Entry FfiEntryList;
-
-typedef struct ArcHandle_FfiEntryList {
-  const FfiEntryList *_0;
-} ArcHandle_FfiEntryList;
-
-typedef struct ArcHandle_FfiEntryList EntryListHandle;
-
-typedef struct ArcHandle_LocalKey {
-  const struct LocalKey *_0;
-} ArcHandle_LocalKey;
-
-typedef struct ArcHandle_LocalKey LocalKeyHandle;
-
 /**
  * ByteBuffer is a struct that represents an array of bytes to be sent over the FFI boundaries.
  * There are several cases when you might want to use this, but the primary one for us
@@ -152,6 +133,25 @@ typedef struct ByteBuffer {
   int64_t len;
   uint8_t *data;
 } ByteBuffer;
+
+typedef struct SecretBuffer {
+  int64_t len;
+  uint8_t *data;
+} SecretBuffer;
+
+typedef struct FfiResultList_Entry FfiEntryList;
+
+typedef struct ArcHandle_FfiEntryList {
+  const FfiEntryList *_0;
+} ArcHandle_FfiEntryList;
+
+typedef struct ArcHandle_FfiEntryList EntryListHandle;
+
+typedef struct ArcHandle_LocalKey {
+  const struct LocalKey *_0;
+} ArcHandle_LocalKey;
+
+typedef struct ArcHandle_LocalKey LocalKeyHandle;
 
 typedef struct EncryptedBuffer {
   struct SecretBuffer buffer;
@@ -240,6 +240,18 @@ typedef void (*LogCallback)(const void *context,
 #ifdef __cplusplus
 extern "C" {
 #endif // __cplusplus
+
+/**
+ * ## Derive password using Argon2
+ *
+ * If the first provided argument is 1, it will use `PARAMS_INTERACTTIVE` and otherwise it will
+ * fallback to `PARAMS_MODERATE`.
+ *
+ */
+ErrorCode askar_argon2_derive_password(int8_t parameter,
+                                       struct ByteBuffer password,
+                                       struct ByteBuffer salt,
+                                       struct SecretBuffer *out);
 
 void askar_buffer_free(struct SecretBuffer buffer);
 

--- a/src/ffi/kdf.rs
+++ b/src/ffi/kdf.rs
@@ -1,0 +1,36 @@
+use crate::ffi::{error::ErrorCode, secret::SecretBuffer};
+use askar_crypto::kdf::{
+    argon2::{Argon2, PARAMS_INTERACTIVE, PARAMS_MODERATE},
+    KeyDerivation,
+};
+use ffi_support::ByteBuffer;
+
+/// ## Derive password using Argon2
+///
+/// If the first provided argument is 1, it will use `PARAMS_INTERACTTIVE` and otherwise it will
+/// fallback to `PARAMS_MODERATE`.
+///
+#[no_mangle]
+pub extern "C" fn askar_argon2_derive_password(
+    parameter: i8,
+    password: ByteBuffer,
+    salt: ByteBuffer,
+    out: *mut SecretBuffer,
+) -> ErrorCode {
+    catch_err! {
+        let params = match parameter {
+            1 => PARAMS_INTERACTIVE,
+            _ => PARAMS_MODERATE,
+        };
+
+        let mut argon2 = Argon2::new(password.as_slice(), salt.as_slice(), params)?;
+
+        let mut key_out: Vec<u8> = vec![];
+
+        argon2.derive_key_bytes(key_out.as_mut_slice())?;
+
+        unsafe { *out = SecretBuffer::from_secret(key_out) };
+
+        Ok(ErrorCode::Success)
+    }
+}

--- a/src/ffi/mod.rs
+++ b/src/ffi/mod.rs
@@ -18,6 +18,7 @@ use self::handle::ResourceHandle;
 mod macros;
 
 mod error;
+mod kdf;
 mod key;
 mod log;
 pub(crate) mod result_list;


### PR DESCRIPTION
We are currently using `react-native-argon2` which uses `CatCrypto` for iOS. After updating to iOS 26, the seems to fail now.
Exposing argon2 over ffi within Askar, instead of making a new library, seems like the best and fastest way for current wallets, i.e. bifold, to make a build working again.

Also add it to the python wrapper for testing purposes. Not a 100% sure if I followed all the python conventions.
