### PR TITLE
fix: aarch64 TLS BadSignature from miscompiled ring assembly

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -3,7 +3,6 @@ name: "Aries-Askar"
 env:
   RUST_VERSION: "1.86.0"
   RUST_NIGHTLY_VERSION: "nightly"
-  CROSS_VERSION: "0.2.4"
   TEST_FEATURES: "default"
 
 concurrency:
@@ -65,11 +64,6 @@ jobs:
       - name: Cargo check
         run: cargo check --workspace
 
-      - if: ${{ runner.os == 'Linux' }}
-        name: Pre-install cross
-        run: |
-          cargo install --bins --git https://github.com/rust-embedded/cross --locked --tag v${{ env.CROSS_VERSION }} cross
-
   tests:
     name: Run tests
     needs: [checks]
@@ -123,15 +117,15 @@ jobs:
       matrix:
         include:
           - architecture: linux-aarch64
-            os: ubuntu-latest
+            os: ubuntu-24.04-arm
             lib: libaries_askar.so
             target: aarch64-unknown-linux-gnu
-            use_cross: true
+            manylinux_image: quay.io/pypa/manylinux2014_aarch64
           - architecture: linux-x86_64
             os: ubuntu-latest
             lib: libaries_askar.so
             target: x86_64-unknown-linux-gnu
-            use_cross: true
+            manylinux_image: quay.io/pypa/manylinux2014_x86_64
           - architecture: darwin-universal
             os: macos-latest
             lib: libaries_askar.dylib
@@ -162,14 +156,16 @@ jobs:
       - name: Build
         shell: sh
         run: |
-          if [ -n "${{ matrix.use_cross }}" ]; then
-            cargo install --bins --git https://github.com/rust-embedded/cross --locked --tag v${{ env.CROSS_VERSION }} cross
-            # Required for compatibility with manylinux2014.
-            # https://github.com/briansmith/ring/issues/1728
-            if [ "${{ matrix.architecture }}" = "linux-aarch64" ]; then
-              export CFLAGS="-D__ARM_ARCH=8"
-            fi
-            cross build --lib --release --target ${{ matrix.target }}
+          if [ -n "${{ matrix.manylinux_image }}" ]; then
+            # Build each Linux target natively in pypa's manylinux2014 image, which has
+            # binutils 2.35 and targets glibc 2.17. The rust-cross images use the older
+            # binutils 2.29.1, which miscompiles ring's aarch64 assembly and causes
+            # openwallet-foundation/askar#401.
+            docker run --rm -v "$PWD":/io -w /io -e CARGO_TARGET_DIR=/io/target \
+              "${{ matrix.manylinux_image }}" bash -c '
+                curl --proto "=https" --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --profile minimal --default-toolchain ${{ env.RUST_VERSION }}
+                export PATH="$HOME/.cargo/bin:$PATH"
+                cargo build --lib --release --target ${{ matrix.target }}'
           elif [ "${{ matrix.architecture }}" == "darwin-universal" ]; then
             ./build-universal.sh
           else

--- a/Cross.toml
+++ b/Cross.toml
@@ -1,8 +1,0 @@
-[build.env]
-passthrough = ["CFLAGS"]
-
-[target.aarch64-unknown-linux-gnu]
-image = "ghcr.io/rust-cross/manylinux2014-cross:aarch64"
-
-[target.x86_64-unknown-linux-gnu]
-image = "ghcr.io/rust-cross/manylinux2014-cross:x86_64"


### PR DESCRIPTION
## Problem

The published `linux-aarch64` library fails to open a TLS connection to Postgres (for example AWS RDS):

```
error communicating with database: invalid peer certificate: BadSignature
```

The same code and database work from `linux-x86_64`. A minimal Credo 0.7.0 reproduction is at https://github.com/rblaine95/askar-401-reproduction.

## Cause

This is the build toolchain, not the Rust code. The `linux-aarch64` and `linux-x86_64` libraries are cross-compiled in the `ghcr.io/rust-cross/manylinux2014-cross` images, which ship `binutils 2.29.1`. That assembler miscompiles the aarch64 assembly in `ring` (briansmith/ring#1728), which is why the workflow already sets `-D__ARM_ARCH=8`. The flag lets `ring` compile, but the emitted aarch64 crypto is wrong, so TLS signature verification fails. The x86_64 assembly is not affected, which is why only arm64 breaks.

Building the same source with a newer assembler produces a working library. Both images target the same glibc:

| image | gcc | binutils | glibc target |
| --- | --- | --- | --- |
| `rust-cross/manylinux2014-cross:aarch64` | 4.8.5 | 2.29.1 | 2.17 |
| `pypa/manylinux2014_aarch64` | 10.2.1 | 2.35 | 2.17 |

## Change

Build both Linux targets natively instead of cross-compiling:

- `linux-aarch64` on an `ubuntu-24.04-arm` runner
- `linux-x86_64` on `ubuntu-latest`

Each builds inside the matching `quay.io/pypa/manylinux2014_<arch>` image. Those images use `binutils 2.35` and still target `glibc 2.17`, so the libraries keep manylinux2014 compatibility. With a correct assembler the `-D__ARM_ARCH=8` workaround is no longer needed.

This removes `cross`, `Cross.toml`, and `CROSS_VERSION` from the Linux builds. The Android job still uses `cross` and is unchanged.

## Testing

I built the library from this branch in `pypa/manylinux2014_aarch64`, dropped it into `@openwallet-foundation/askar-nodejs`, and the Credo agent connected to an SSL RDS instance with no BadSignature error. The current release reproduces the error with the same setup. The built library reports `GLIBC_2.17` as its highest required symbol.

Closes #401
